### PR TITLE
Remove scheduled runs and fix syntax error

### DIFF
--- a/.github/workflows/boom-check.yml
+++ b/.github/workflows/boom-check.yml
@@ -2,9 +2,6 @@
 
 name: Boom SLA (API, REST)
 on:
-  # Keep the existing 5‑minute schedule so the checker still runs regularly
-  schedule:
-    - cron: "*/5 * * * *"     # every 5 minutes
   # Allow manual runs from the Actions UI with an optional conversation input
   workflow_dispatch:
     inputs:

--- a/check.mjs
+++ b/check.mjs
@@ -505,7 +505,6 @@ async function sendEmail(subject, html) {
     const bodyHtml = `<p>Guest appears unanswered ≥ ${SLA_MINUTES} minutes.</p>${linkHtml}`;
     await sendEmail(subj, bodyHtml);
     console.log("⚠️ Alert email sent.");
- Alert email sent.");
   } else {
     console.log("No alert sent.");
   }


### PR DESCRIPTION
## Summary
- remove cron schedule so only manual or dispatch runs trigger
- fix stray JavaScript line that caused parse error

## Testing
- `node --check check.mjs`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8cbf866c8832a8c0010e9c6e5aad1