### PR TITLE
Ensure SLA alert triggers only after full interval

### DIFF
--- a/check.mjs
+++ b/check.mjs
@@ -449,9 +449,14 @@ function evaluate(messages, now = new Date(), slaMin = SLA_MINUTES) {
     return { ok: true, reason: "no_breach" };
   }
 
-  // Compute the minutes since the last unanswered guest message
-  const minsSinceGuest = Math.floor((now - lastGuestTs) / 60000);
-  if (minsSinceGuest >= slaMin) {
+  // Compute the time since the last unanswered guest message using
+  // millisecond precision to avoid early firing caused by rounding.
+  // The alert should trigger only when the full SLA interval has
+  // elapsed.  We still expose a minutes count (rounded down) in the
+  // result for logging purposes.
+  const diffMs = now - lastGuestTs;
+  const minsSinceGuest = Math.floor(diffMs / 60000);
+  if (diffMs >= slaMin * 60000) {
     return { ok: false, reason: "guest_unanswered", minsSinceAgent: minsSinceGuest };
   }
   return { ok: true, reason: "within_sla", minsSinceAgent: minsSinceGuest };


### PR DESCRIPTION
## Summary
- prevent early SLA alerts by calculating unanswered interval in milliseconds
- document logic to fire only when full SLA minutes have elapsed

## Testing
- `node --version`
- `node --check check.mjs`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a986188f58832a98cb478bf4cba05f