### PR TITLE
Handle additional timestamp fields

### DIFF
--- a/check.mjs
+++ b/check.mjs
@@ -395,7 +395,15 @@ function whoSent(m) {
 }
 
 function tsOf(m) {
-  const t = m.sent_at || m.createdAt || m.timestamp || m.ts || m.time || null;
+  const t =
+    m.sent_at ||
+    m.sentAt ||
+    m.created_at ||
+    m.createdAt ||
+    m.timestamp ||
+    m.ts ||
+    m.time ||
+    null;
   const d = t ? new Date(t) : null;
   return d && !isNaN(+d) ? d : null;
 }


### PR DESCRIPTION
## Summary
- detect more timestamp field names (`sentAt`, `created_at`) when parsing messages
- helps correctly find agent replies and prevents false unanswered alerts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node check.mjs` *(fails: LOGIN_URL or BOOM_USER/BOOM_PASS missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa016b2530832aa268695b13b47c6a