### PR TITLE
chore: cache npm deps in CI

### DIFF
--- a/.github/workflows/boom-check.yml
+++ b/.github/workflows/boom-check.yml
@@ -47,12 +47,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: 'npm'
       - name: Install deps
         run: |
           if [ -f package-lock.json ]; then
-            npm ci
+            npm ci --prefer-offline --no-audit
           else
-            npm i
+            npm i --prefer-offline --no-audit
           fi
       - name: Run SLA checker
         run: node check.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "boom-sla-check",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "boom-sla-check",
+      "version": "1.0.0",
+      "dependencies": {
+        "nodemailer": "^6.9.13"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- cache npm dependencies in workflow
- ignore node_modules and add npm lockfile

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node check.mjs` *(fails: LOGIN_URL or BOOM_USER/BOOM_PASS missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6e1d3ff8832aa8b9186691ac2f3b