### PR TITLE
Forward Boom notification payload to workflow

### DIFF
--- a/.github/workflows/boom-check.yml
+++ b/.github/workflows/boom-check.yml
@@ -42,6 +42,8 @@ jobs:
       # if none are present this will evaluate to an empty string and the checker will fall back to the default conversation ID.
       CONVERSATION_INPUT: ${{ github.event.inputs.conversation || github.event.client_payload.conversation || github.event.client_payload.conversationUrl || github.event.client_payload.conversation_url }}
       DEFAULT_CONVERSATION_ID: ${{ vars.DEFAULT_CONVERSATION_ID }}
+      # Forward the raw Boom notification for scripts that parse additional context
+      BOOM_NOTIFICATION: ${{ toJSON(github.event.client_payload.notification || github.event.client_payload.boom_notification || '') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/email.mjs
+++ b/email.mjs
@@ -1,0 +1,51 @@
+import nodemailer from "nodemailer";
+
+/**
+ * Send an alert email using SMTP credentials from environment variables.
+ *
+ * Required env vars:
+ *   - SMTP_HOST
+ *   - SMTP_PORT
+ *   - SMTP_USER
+ *   - SMTP_PASS
+ *   - ALERT_TO
+ * Optional:
+ *   - ALERT_FROM_NAME
+ *
+ * @param {object} opts
+ * @param {string} opts.subject Email subject
+ * @param {string} opts.html    HTML body content
+ * @param {string} opts.text    Plain text body content
+ */
+export async function sendAlert({ subject, html, text }) {
+  const host = process.env.SMTP_HOST;
+  const port = Number(process.env.SMTP_PORT || 587);
+  const user = process.env.SMTP_USER;
+  const pass = process.env.SMTP_PASS;
+  const to   = process.env.ALERT_TO;
+  const fromName = process.env.ALERT_FROM_NAME || "Boom SLA Bot";
+
+  if (!host || !port || !user || !pass || !to) {
+    console.log("Alert needed, but SMTP/recipient envs are not fully set.");
+    return { sent: false, reason: "smtp_missing" };
+  }
+
+  const transporter = nodemailer.createTransport({
+    host,
+    port,
+    secure: port === 465,
+    auth: { user, pass },
+  });
+
+  const message = {
+    from: `"${fromName}" <${user}>`,
+    to,
+    subject,
+    text,
+    html,
+  };
+
+  await transporter.sendMail(message);
+  return { sent: true };
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "boom-sla-check",
       "version": "1.0.0",
       "dependencies": {
-        "@vitalets/google-translate-api": "^8.0.0"
+        "@vitalets/google-translate-api": "^8.0.0",
+        "nodemailer": "^6.9.13"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -283,6 +284,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/normalize-url": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "@vitalets/google-translate-api": "^8.0.0"
+    "@vitalets/google-translate-api": "^8.0.0",
+    "nodemailer": "^6.9.13"
   }
 }


### PR DESCRIPTION
## Summary
- forward Boom notification payload from repository dispatch events to the SLA checker via env var

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b082a18940832a9f6ab90be6b19a2e