### PR TITLE
fix: restore azure function deploy workflow

### DIFF
--- a/.github/workflows/deploy-boom-notify.yml
+++ b/.github/workflows/deploy-boom-notify.yml
@@ -14,8 +14,12 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install deps (function dir)
-        run: npm ci
+      - run: npm ci
         working-directory: azure/boom-notify
 
-      - name: Package
+      - name: Deploy to Azure Functions (publish profile)
+        uses: Azure/functions-action@v1
+        with:
+          app-name: boom-webhook-func
+          package: azure/boom-notify
+          publish-profile: ${{ secrets.AZURE_FUNC_PUBLISH_PROFILE }}


### PR DESCRIPTION
## Summary
- fix deploy boom-notify workflow by restoring deploy step

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b218f751f4832a9e701761c9b4019a