### PR TITLE
chore: simplify shared secret header check

### DIFF
--- a/azure/boom-notify/boom-notify/index.js
+++ b/azure/boom-notify/boom-notify/index.js
@@ -53,7 +53,9 @@ export default async function (context, req) {
     // Optional shared-secret header check (set SHARED_SECRET in App Settings)
     const sharedSecret = process.env.SHARED_SECRET || "";
     if (sharedSecret) {
-      const incoming = req.headers["x-shared-secret"] || req.headers["X-Shared-Secret".toLowerCase()];
+      // Node normalises request header names to lowercase, so a single lookup
+      // covers any client-provided casing of `X-Shared-Secret`.
+      const incoming = req.headers["x-shared-secret"];
       if (incoming !== sharedSecret) {
         context.log.warn("Shared secret mismatch");
         context.res = { status: 401, body: "Unauthorized" };


### PR DESCRIPTION
## Summary
- avoid redundant header lookups when verifying X-Shared-Secret in Azure Function

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "import('./azure/boom-notify/boom-notify/index.js').then(()=>console.log('loaded')).catch(err=>console.error(err))"`

------
https://chatgpt.com/codex/tasks/task_e_68b220113664832a9510c3735036b242