### PR TITLE
fix: simplify azure function deploy

### DIFF
--- a/.github/workflows/deploy-boom-notify.yml
+++ b/.github/workflows/deploy-boom-notify.yml
@@ -16,15 +16,9 @@ jobs:
 
       - run: npm ci
         working-directory: azure/boom-notify
-
-      - name: Create deployment package
-        run: |
-          zip -r boom-notify.zip .
-        working-directory: azure/boom-notify
-
       - name: Deploy to Azure Functions (publish profile)
         uses: Azure/functions-action@v1
         with:
           app-name: boom-webhook-func
-          package: azure/boom-notify/boom-notify.zip
+          package: azure/boom-notify
           publish-profile: ${{ secrets.AZURE_FUNC_PUBLISH_PROFILE }}


### PR DESCRIPTION
## Summary
- deploy Azure function by pointing action to source directory
- remove custom zip step to avoid concurrency error

## Testing
- `npm ci --prefix azure/boom-notify`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2217a864c832aa99a7890036aebb2