### PR TITLE
ci(deploy): normalize Kudu endpoint (add https scheme) to fix curl 52

### DIFF
--- a/.github/workflows/deploy-boom-notify.yml
+++ b/.github/workflows/deploy-boom-notify.yml
@@ -57,7 +57,14 @@ jobs:
           KUDU_SCM:  ${{ env.KUDU_SCM }}
         run: |
           set -euo pipefail
+          # Normalize endpoint (add https:// if missing, drop trailing slash)
+          if [[ "${KUDU_SCM}" != http*://* ]]; then
+            KUDU_SCM="https://${KUDU_SCM}"
+          fi
+          KUDU_SCM="${KUDU_SCM%/}"
           echo "Kudu endpoint: $KUDU_SCM"
+
+          # Robust upload
           curl --fail --show-error --silent \
                --http1.1 \
                -H "Content-Type: application/zip" \


### PR DESCRIPTION
## Summary
- normalize Kudu endpoint before zipdeploy

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b231bb89d8832abccda14d40e22c14