### PR TITLE
ci(deploy): use npm install and include node_modules in ZIP for Azure Functions

### DIFF
--- a/.github/workflows/deploy-boom-notify.yml
+++ b/.github/workflows/deploy-boom-notify.yml
@@ -17,13 +17,16 @@ jobs:
 
       - name: Install deps (function dir)
         working-directory: azure/boom-notify
-        run: npm ci
+        run: |
+          npm install --omit=dev
+          npm prune --omit=dev
 
       - name: Package function (zip)
         working-directory: azure/boom-notify
         run: |
           rm -f ../functionapp.zip
-          zip -r ../functionapp.zip host.json package.json boom-notify
+          # include node_modules so the app runs without remote build
+          zip -r ../functionapp.zip host.json package.json node_modules boom-notify
           ls -lh ../functionapp.zip
 
       - name: Install xmllint
@@ -47,10 +50,11 @@ jobs:
           echo "pass=$PASS"   >> $GITHUB_OUTPUT
 
       - name: ZipDeploy to Kudu (publish profile)
+        working-directory: azure/boom-notify
         shell: bash
         run: |
           curl -sS -u "${{ steps.parse.outputs.user }}:${{ steps.parse.outputs.pass }}" \
             -X POST \
             -H "Content-Type: application/zip" \
-            --data-binary @"azure/functionapp.zip" \
+            --data-binary @"../functionapp.zip" \
             "https://${{ steps.parse.outputs.scm }}/api/zipdeploy" | jq .


### PR DESCRIPTION
## Summary
- use `npm install` and prune in Azure Functions workflow to skip `npm ci`
- package `node_modules` in function zip and deploy the archive directly

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2f82513a8832a9d5c840ac104d868