### PR TITLE
fix(ci): run npm at repo root; fallback when no lockfile

### DIFF
--- a/.github/workflows/boom-check.yml
+++ b/.github/workflows/boom-check.yml
@@ -28,5 +28,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - run: npm ci
-      - run: node check.mjs
+      - name: Install deps
+        working-directory: .
+        run: |
+          ls -la
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --no-fund --no-audit
+          fi
+      - name: Run SLA checker
+        working-directory: .
+        run: node ./check.mjs

--- a/.github/workflows/boom-sla-cron.yml
+++ b/.github/workflows/boom-sla-cron.yml
@@ -42,7 +42,15 @@ jobs:
           node-version: 20
 
       - name: Install deps
-        run: npm ci
+        working-directory: .
+        run: |
+          ls -la
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --no-fund --no-audit
+          fi
 
       - name: Run SLA checker
-        run: node check.mjs
+        working-directory: .
+        run: node ./check.mjs


### PR DESCRIPTION
## Summary
- ensure workflows run npm from repo root, falling back when no lockfile
- pass repo root to SLA checker

## Testing
- `npm test` *(fails: Missing script: "test")*
- `git push -u origin "codex/fix-ci-run-root"` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b35f522d00832a9c4a24f0834abafd