### PR TITLE
Cron: run every 5m and actually execute; add FORCE_RUN to bypass schedule skip

### DIFF
--- a/.github/workflows/boom-sla-cron.yml
+++ b/.github/workflows/boom-sla-cron.yml
@@ -2,7 +2,7 @@ name: Boom SLA check (cron)
 
 on:
   schedule:
-    - cron: "*/1 * * * *"   # every minute
+    - cron: "*/5 * * * *"   # every 5 minutes
   workflow_dispatch: {}      # allow manual runs
 
 concurrency:
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
+      FORCE_RUN: 1
       # non-secret repo variables (already set in your repo)
       LOGIN_URL:                  ${{ vars.LOGIN_URL }}
       LOGIN_METHOD:               ${{ vars.LOGIN_METHOD }}

--- a/check.mjs
+++ b/check.mjs
@@ -1,3 +1,4 @@
+const FORCE_RUN = process.env.FORCE_RUN === "1";
 import fs from "fs";
 import translate from "@vitalets/google-translate-api";
 import { sendAlert } from "./email.mjs";
@@ -639,7 +640,7 @@ async function evaluate(messages, now = new Date(), slaMin = SLA_MINUTES) {
   // invocations (e.g. repository_dispatch) to proceed.  This prevents
   // multiple alerts from being generated on a fixed interval.
   const eventName = process.env.GITHUB_EVENT_NAME || "";
-  if (eventName.toLowerCase() === "schedule") {
+  if (!FORCE_RUN && eventName.toLowerCase() === "schedule") {
     console.log("Scheduled run detected; skipping check.");
     return;
   }


### PR DESCRIPTION
## Summary
- run cron workflow every 5 minutes
- allow cron execution despite schedule by checking FORCE_RUN

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3e4eec13c832a81173863b1660a82