### PR TITLE
Handle empty conversation lists in SLA cron

### DIFF
--- a/cron.mjs
+++ b/cron.mjs
@@ -74,7 +74,10 @@ async function listConversations() {
                Array.isArray(data.results) ? data.results : [];
 
   const ids = [...new Set(list.map(x => x?.conversationId || x?.id || x?.uuid).filter(Boolean))];
-  if (!ids.length) throw new Error('No conversation ids found in conversations response.');
+  if (!ids.length) {
+    console.warn('No conversation ids found in conversations response; nothing to check.');
+    return [];
+  }
   return ids;
 }
 


### PR DESCRIPTION
## Summary
- avoid failing cron when conversation API returns no IDs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node cron.mjs` *(fails: CONVERSATIONS_URL not set and could not infer from MESSAGES_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f12eaea0832a97661ba20d1c8184