### PR TITLE
Deep-scan conversations JSON for ids

### DIFF
--- a/cron.mjs
+++ b/cron.mjs
@@ -55,28 +55,57 @@ async function listConversations() {
   if(!url) throw new Error('CONVERSATIONS_URL not set and could not infer from MESSAGES_URL');
   const method = env('CONVERSATIONS_METHOD','GET').toUpperCase();
 
-  const authFetch = buildAuthFetch();
+  const authFetch = buildAuthFetch?.() || fetch;
   const res = await authFetch(url,{ method, headers:{accept:'application/json'} });
   const status = res.status;
   const ctype = String(res.headers?.get?.('content-type')||'').toLowerCase();
   const text  = await res.text();
 
   if (!ctype.includes('application/json')) {
-    throw new Error(`CONVERSATIONS_URL returned non-JSON (${ctype || 'unknown'}), status ${status}. First bytes: ${text.slice(0,160)}`);
+    throw new Error(`CONVERSATIONS_URL returned non-JSON (${ctype||'unknown'}), status ${status}. First bytes: ${text.slice(0,160)}`);
   }
 
   let data;
   try { data = JSON.parse(text); } catch(e){ throw new Error('Bad JSON from conversations: '+e.message+' — first bytes: '+text.slice(0,160)); }
 
-  const list = Array.isArray(data) ? data :
-               Array.isArray(data.conversations) ? data.conversations :
-               Array.isArray(data.items) ? data.items :
-               Array.isArray(data.results) ? data.results : [];
+  // Flexible extraction
+  const guessArray = (obj) => {
+    if (Array.isArray(obj)) return obj;
+    if (Array.isArray(obj?.conversations)) return obj.conversations;
+    if (Array.isArray(obj?.items)) return obj.items;
+    if (Array.isArray(obj?.results)) return obj.results;
+    if (Array.isArray(obj?.data)) return obj.data;
+    if (obj?.conversations?.data && Array.isArray(obj.conversations.data)) return obj.conversations.data;
+    if (obj?.data?.conversations && Array.isArray(obj.data.conversations)) return obj.data.conversations;
+    if (obj?.data?.items && Array.isArray(obj.data.items)) return obj.data.items;
+    return null;
+  };
 
-  const ids = [...new Set(list.map(x => x?.conversationId || x?.id || x?.uuid).filter(Boolean))];
+  const arr = guessArray(data);
+
+  const deepIds = new Set();
+  const wanted = new Set(['conversationid','id','uuid']);
+
+  const walk = (x) => {
+    if (!x || typeof x !== 'object') return;
+    if (Array.isArray(x)) { x.forEach(walk); return; }
+    for (const [k,v] of Object.entries(x)) {
+      if (wanted.has(String(k).toLowerCase()) && (typeof v === 'string' || typeof v === 'number')) {
+        const val = String(v).trim();
+        if (val) deepIds.add(val);
+      }
+      if (v && typeof v === 'object') walk(v);
+    }
+  };
+
+  if (arr) walk(arr); else walk(data);
+
+  const ids = Array.from(deepIds);
   if (!ids.length) {
-    console.warn('No conversation ids found in conversations response; nothing to check.');
-    return [];
+    const topKeys = Object.keys(data || {});
+    const preview = text.slice(0, 400).replace(/\s+/g, ' ');
+    console.log('No conversation ids found. Top-level keys:', topKeys);
+    console.log('Preview:', preview);
   }
   return ids;
 }


### PR DESCRIPTION
## Summary
- enhance conversation listing to detect IDs in varied JSON structures
- log top-level keys and response preview when no IDs are found

## Testing
- `node --check cron.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68b3f2b96e84832aae2487c605bd6a5d