### PR TITLE
checker: support POST conversations endpoint via CONVERSATIONS_BODY; better error logs

### DIFF
--- a/.github/workflows/boom-sla-cron.yml
+++ b/.github/workflows/boom-sla-cron.yml
@@ -22,6 +22,7 @@ jobs:
       MESSAGES_METHOD:            ${{ vars.MESSAGES_METHOD }}
       CONVERSATIONS_URL:          ${{ vars.CONVERSATIONS_URL }}
       CONVERSATIONS_METHOD:       ${{ vars.CONVERSATIONS_METHOD }}
+      CONVERSATIONS_BODY:          ${{ vars.CONVERSATIONS_BODY }}
       SLA_MINUTES:                ${{ vars.SLA_MINUTES }}
       DEBUG:                      ${{ vars.DEBUG }}
       DEBUG_MESSAGES:             ${{ vars.DEBUG_MESSAGES }}


### PR DESCRIPTION
## Summary
- allow passing request body and extra headers for conversation listing
- improve error logging for conversation endpoint responses

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3f43c2f68832a8cc07c2596b11985