### PR TITLE
chore: disable scheduled SLA check

### DIFF
--- a/.github/workflows/boom-sla-cron.yml
+++ b/.github/workflows/boom-sla-cron.yml
@@ -1,8 +1,8 @@
 name: Boom SLA check (cron)
 
 on:
-  schedule:
-    - cron: "*/5 * * * *"   # every 5 minutes
+  # schedule:
+  #   - cron: "*/5 * * * *"   # every 5 minutes
   workflow_dispatch: {}      # allow manual runs
 
 concurrency:


### PR DESCRIPTION
## Summary
- temporarily disable scheduled SLA check workflow

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b61db7c7f0832aa1bf8f1a3a939ade