### PR TITLE
Add optional debug step for conversations endpoint

### DIFF
--- a/.github/workflows/boom-sla-cron.yml
+++ b/.github/workflows/boom-sla-cron.yml
@@ -55,6 +55,18 @@ jobs:
             npm install --no-fund --no-audit
           fi
 
+      # Debug the conversations listing endpoint (enable with DEBUG=1)
+      - name: Debug conversations endpoint
+        if: ${{ env.DEBUG == '1' }}
+        run: |
+          set -euo pipefail
+          echo "Hitting: $CONVERSATIONS_URL"
+          curl -i -sS -X "${CONVERSATIONS_METHOD:-GET}" "$CONVERSATIONS_URL" \
+            -H "Accept: application/json" \
+            ${CONVERSATIONS_AUTH_HEADER_NAME:+-H "${CONVERSATIONS_AUTH_HEADER_NAME}: ${CONVERSATIONS_AUTH_VALUE}"} \
+            ${CSRF_HEADER_NAME:+-H "${CSRF_HEADER_NAME}: ${CSRF_HEADER_VALUE:-}"} \
+            ${CONVERSATIONS_BODY:+--data "$CONVERSATIONS_BODY"} | sed -e 's/Authorization: .*/Authorization: <redacted>/'
+
       - name: Run SLA checker
         working-directory: .
         run: node ./cron.mjs


### PR DESCRIPTION
## Summary
- add a debugging step to the cron workflow to inspect the conversations listing endpoint when `DEBUG=1`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf4b84b2d4832a8776ca6d0f5853c1