### PR TITLE
Improve debug conversations endpoint step

### DIFF
--- a/.github/workflows/boom-sla-cron.yml
+++ b/.github/workflows/boom-sla-cron.yml
@@ -64,29 +64,39 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Read and sanitize the URL (strip CR/LF to avoid curl error 3)
-          url_raw="${CONVERSATIONS_URL:-}"
-          if [ -z "${url_raw}" ]; then
+          # 1) Read and sanitize the URL from env (strip CR/LF/tabs and surrounding quotes/brackets)
+          raw="${CONVERSATIONS_URL:-}"
+          if [ -z "${raw}" ]; then
             echo "::error::CONVERSATIONS_URL is empty"; exit 1
           fi
-          url="$(printf '%s' "$url_raw" | tr -d '\r\n')"
 
-          # Warn if spaces; encode them so curl won’t choke
-          if printf '%s' "$url" | grep -q ' '; then
-            echo "::warning::Spaces detected in CONVERSATIONS_URL; encoding as %20"
-            url="${url// /%20}"
-          fi
+          # Remove CR, LF, TAB
+          url="$(printf '%s' "$raw" | tr -d '\r\n\t')"
 
-          echo "Hitting: $url"
+          # Strip surrounding angle/smart quotes if someone pasted with them
+          url="${url#<}"; url="${url%>}"
+          url="${url#"}"; url="${url%"}"
+          url="${url#'}"; url="${url%'}"
+          url="${url#“}"; url="${url%”}"
+          url="${url#‘}"; url="${url%’}"
 
-          # --globoff avoids curl interpreting [] in query params (e.g. filter[status]=open)
-          # --fail makes curl exit non-zero on HTTP >= 400
-          # --show-error prints the error text when failing
-          curl -sS --fail --show-error --globoff "$url" -w "\nHTTP %{http_code}\n" || {
-            code=$?
-            echo "::error::curl failed with exit code $code"
-            exit $code
-          }
+          # If there are literal spaces, encode them (curl would reject them)
+          case "$url" in
+            *" "*) echo "::warning::Spaces found in URL; encoding as %20"; url="${url// /%20}";;
+          esac
+
+          echo "Hitting (sanitized): $url"
+
+          # 2) Print raw bytes so hidden characters are visible in logs
+          printf 'URL bytes (hex): '
+          printf '%s' "$url" | od -An -t x1 | tr -d '\n'
+          echo
+
+          # 3) Safe curl:
+          #    -g/--globoff: ignore [] globbing in query params
+          #    -L: follow redirects
+          #    --fail --show-error: fail clearly on HTTP 4xx/5xx
+          curl -sS -L --fail --show-error --globoff "$url" -w "\nHTTP %{http_code}\n"
 
       - name: Run SLA checker
         working-directory: .


### PR DESCRIPTION
## Summary
- tighten up URL sanitization and diagnostics for the conversations endpoint debug step

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf566bb2e0832a8ef521085498cc12