### PR TITLE
Remove smart quote filters from SLA cron debug

### DIFF
--- a/.github/workflows/boom-sla-cron.yml
+++ b/.github/workflows/boom-sla-cron.yml
@@ -74,8 +74,6 @@ jobs:
           url="${url#<}"; url="${url%>}"
           url="${url#\"}"; url="${url%\"}"
           url="${url#\'}"; url="${url%\'}"
-          url="${url#“}"; url="${url%”}"
-          url="${url#‘}"; url="${url%’}"
 
           # Encode spaces if any
           case "$url" in *" "*) url="${url// /%20}";; esac


### PR DESCRIPTION
## Summary
- drop smart quote sanitization from the Debug conversations endpoint step in cron workflow

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf5acf2ac0832aa13904ac1dfdbce7