### PR TITLE
Use unified jf for messages fetch

### DIFF
--- a/check.mjs
+++ b/check.mjs
@@ -1,4 +1,9 @@
-const FORCE_RUN = process.env.FORCE_RUN === "1";
+  // Include AJAX header and bearer token (if present)
+  const headers = {
+    'x-requested-with': 'XMLHttpRequest',
+    ...((token) ? { authorization: `Bearer ` } : {})
+  };
+  const res = await jf(messagesUrl, { method: MESSAGES_METHOD, headers });const FORCE_RUN = process.env.FORCE_RUN === "1";
 import fs from "fs";
 import translate from "@vitalets/google-translate-api";
 import { sendAlert } from "./email.mjs";
@@ -266,7 +271,7 @@ const jar = new Jar();
 async function jf(url, init = {}) {
   const headers = new Headers(init.headers || {});
   headers.set("accept", "application/json, text/plain, */*");
-  // Ensure JSON endpoints that expect AJAX-style requests don't 406
+  // Prevent 406s on JSON endpoints that expect AJAX-style requests
   headers.set("x-requested-with", "XMLHttpRequest");
   const ck = jar.header();
   if (ck) headers.set("cookie", ck);
@@ -664,13 +669,12 @@ async function evaluate(messages, now = new Date(), slaMin = SLA_MINUTES) {
   if (!MESSAGES_URL_TMPL) throw new Error("MESSAGES_URL not set");
 
   const messagesUrl = MESSAGES_URL_TMPL.replace(/{{conversationId}}/g, id);
-  // Use the same auth machinery as conversation listing and include AJAX header
-  const authFetch = buildAuthFetch?.() || fetch;
+  // Include AJAX header and bearer token (if present)
   const headers = {
     'x-requested-with': 'XMLHttpRequest',
-    ...(token ? { Authorization: `Bearer ${token}` } : {})
+    ...(token ? { authorization: `Bearer ${token}` } : {})
   };
-  const res = await authFetch(messagesUrl, { method: MESSAGES_METHOD, headers });
+  const res = await jf(messagesUrl, { method: MESSAGES_METHOD, headers });
   if (res.status >= 400) throw new Error(`Messages fetch failed: ${res.status}`);
 
   // 3) Parse and evaluate


### PR DESCRIPTION
## Summary
- set `x-requested-with` header in `jf` helper to avoid 406 responses on JSON endpoints
- fetch conversation messages via `jf`, passing AJAX header and bearer token

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check check.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68c0493e2f30832ab65e91eb8286cfe5