### PR TITLE
Allow debug probe to continue on 401

### DIFF
--- a/.github/workflows/boom-sla-check.yml
+++ b/.github/workflows/boom-sla-check.yml
@@ -41,6 +41,7 @@ jobs:
           fi
 
       - name: Debug conversations endpoint
+        continue-on-error: true
         shell: bash
         env:
           BOOM_BEARER: ${{ secrets.BOOM_BEARER }}
@@ -70,7 +71,7 @@ jobs:
             echo "No auth provided; expect 401"
           fi
           # never fail the job here, even on 401
-          code=$(curl -sS --globoff -o /tmp/resp.json -w '%{http_code}' "${hdrs[@]}" "$url" || true)
+          code=$(curl -sS --globoff -o /tmp/resp.json -w '%{http_code}' "${hdrs[@]}" "$url" || true) || true
           echo "HTTP $code"
           head -c 400 /tmp/resp.json || true
 

--- a/.github/workflows/boom-sla-cron.yml
+++ b/.github/workflows/boom-sla-cron.yml
@@ -56,6 +56,7 @@ jobs:
           fi
 
       - name: Debug conversations endpoint
+        continue-on-error: true
         if: env.DEBUG == '1'
         env:
           # Use whichever you already have configured
@@ -86,7 +87,7 @@ jobs:
           echo
 
           # Safe curl: disable globbing; follow redirects; fail clearly
-          curl -sS -L --fail --show-error --globoff "$url" -w "\nHTTP %{http_code}\n"
+          curl -sS -L --fail --show-error --globoff "$url" -w "\nHTTP %{http_code}\n" || true
 
       - name: Debug conversations endpoint (rebuild query)
         if: env.DEBUG == '1'


### PR DESCRIPTION
## Summary
- make debugging steps resilient to 401 errors

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c04b029920832ab90a82f52b001ce9