### PR TITLE
Handle conversation placeholder in cron workflow

### DIFF
--- a/.github/workflows/boom-sla-cron.yml
+++ b/.github/workflows/boom-sla-cron.yml
@@ -100,6 +100,15 @@ jobs:
             --data-urlencode "all=true" \
             -w "\nHTTP %{http_code}\n"
 
+      - name: Normalize messages URL
+        shell: bash
+        run: |
+          if [[ "$MESSAGES_URL" != *"{{conversationId}}"* && "$MESSAGES_URL" != *"conversation="* ]]; then
+            echo "MESSAGES_URL=${MESSAGES_URL}?conversation={{conversationId}}" >> $GITHUB_ENV
+          else
+            echo "MESSAGES_URL=${MESSAGES_URL}" >> $GITHUB_ENV
+          fi
+
       - name: Run SLA checker
         working-directory: .
         run: node ./cron.mjs


### PR DESCRIPTION
## Summary
- ensure MESSAGES_URL in scheduled workflow only appends conversation query when missing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0590ae394832ab7d7bd10a713b1dd