### PR TITLE
Handle conversation discovery and 5xx failures gracefully

### DIFF
--- a/check.mjs
+++ b/check.mjs
@@ -783,8 +783,16 @@ async function evaluate(messages, now = new Date(), slaMin = SLA_MINUTES) {
     }
     if (res && res.status < 400) break;
   }
-  if (!res || res.status >= 400) {
-    throw new Error(`Messages fetch failed: ${lastStatus ?? (res ? res.status : 'unknown')}`);
+  if (!res) {
+    throw new Error(`Messages fetch failed: ${lastStatus ?? 'unknown'}`);
+  }
+  if (res.status >= 500) {
+    console.warn(`Messages endpoint 5xx (${res.status}); skipping conversation`);
+    console.log('No alert sent.');
+    process.exit(0);
+  }
+  if (res.status >= 400) {
+    throw new Error(`Messages fetch failed: ${res.status}`);
   }
 
   // 3) Parse and evaluate


### PR DESCRIPTION
## Summary
- Prefer UUID conversation IDs when listing
- Continue cron processing despite individual check failures
- Soft-skip conversations when messages endpoint returns 5xx

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c0614faec0832a9807d7a3ee4f8acb