### PR TITLE
Deep-link emails to conversation route

### DIFF
--- a/check.mjs
+++ b/check.mjs
@@ -303,7 +303,9 @@ function buildConversationLink() {
         u.pathname = "/" + slice.join("/");
         return u.toString();
       }
-      return u.origin;
+      // No UUID in path (e.g. query style .../messages?conversation=<id>).
+      // Deep-link to the UI conversation route instead of a generic origin.
+      return `${u.origin}/conversations/${encodeURIComponent(id)}`;
     } catch {}
   }
   return id ? id.toString() : "";


### PR DESCRIPTION
## Summary
- Ensure `buildConversationLink` creates a UI deep-link when messages URL lacks a UUID

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0653b2b2c832aa60bc04d96fe5ebb