### PR TITLE
ci: pass BOOM_COOKIE to cron workflow

### DIFF
--- a/.github/workflows/boom-cron.yml
+++ b/.github/workflows/boom-cron.yml
@@ -51,6 +51,7 @@ jobs:
       SMTP_PASS:   ${{ secrets.SMTP_PASS }}
       ALERT_TO:    ${{ secrets.ALERT_TO }}
       ALERT_FROM_NAME: ${{ secrets.ALERT_FROM_NAME }}
+      BOOM_COOKIE: ${{ secrets.BOOM_COOKIE }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- pass BOOM_COOKIE secret to cron workflow

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0ce35e110832a94c2ee441141d420