### PR TITLE
fix(sla): per-conversation debug, auth on messages fetch, limit checks

### DIFF
--- a/.github/workflows/boom-cron.yml
+++ b/.github/workflows/boom-cron.yml
@@ -26,6 +26,8 @@ jobs:
       SLA_MINUTES:                ${{ vars.SLA_MINUTES }}
       # Turn on verbose logs for one run; remove later if noisy
       DEBUG: "1"
+      # limit how many conversations to process per run while debugging
+      CHECK_LIMIT: "50"
       DEBUG_MESSAGES:             ${{ vars.DEBUG_MESSAGES }}
       COUNT_AI_SUGGESTION_AS_AGENT: ${{ vars.COUNT_AI_SUGGESTION_AS_AGENT }}
 


### PR DESCRIPTION
## Summary
- limit conversation checks via CHECK_LIMIT when debugging
- add per-conversation logging when spawning checks
- expose CHECK_LIMIT in cron workflow for throttling

## Testing
- `node --check cron.mjs`
- `node --check check.mjs`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0d45af378832aa74f5d05b804c23e