### PR TITLE
fix(sla): use inline thread, skip broken messages endpoint, send alerts from cron

### DIFF
--- a/.github/workflows/boom-cron.yml
+++ b/.github/workflows/boom-cron.yml
@@ -23,10 +23,11 @@ jobs:
       CONVERSATIONS_URL:          ${{ vars.CONVERSATIONS_URL }}
       CONVERSATIONS_METHOD:       ${{ vars.CONVERSATIONS_METHOD }}
       CONVERSATIONS_BODY:          ${{ vars.CONVERSATIONS_BODY }}
-      SLA_MINUTES:                ${{ vars.SLA_MINUTES }}
+      # alert threshold in minutes (adjust as needed)
+      SLA_MINUTES: "15"
       # Turn on verbose logs for one run; remove later if noisy
       DEBUG: "1"
-      # limit how many conversations to process per run while debugging
+      # process this many conversations per run while tuning
       CHECK_LIMIT: "50"
       DEBUG_MESSAGES:             ${{ vars.DEBUG_MESSAGES }}
       COUNT_AI_SUGGESTION_AS_AGENT: ${{ vars.COUNT_AI_SUGGESTION_AS_AGENT }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@vitalets/google-translate-api": "^8.0.0",
-        "nodemailer": "^6.9.13"
+        "nodemailer": "^6.9.8"
       }
     },
     "node_modules/@sindresorhus/is": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
   "private": true,
   "dependencies": {
     "@vitalets/google-translate-api": "^8.0.0",
-    "nodemailer": "^6.9.13"
+    "nodemailer": "^6.9.8"
   }
 }


### PR DESCRIPTION
## Summary
- read inline conversation threads to compute guest wait times
- email SLA alerts via SMTP
- add SLA limit vars to cron workflow

## Testing
- `node --check cron.mjs`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c0da22f2b8832a91303cdb086ce664