### PR TITLE
feat(alerts): include conversation link in emails and set SLA to 5m

### DIFF
--- a/.github/workflows/boom-cron.yml
+++ b/.github/workflows/boom-cron.yml
@@ -24,7 +24,7 @@ jobs:
       CONVERSATIONS_METHOD:       ${{ vars.CONVERSATIONS_METHOD }}
       CONVERSATIONS_BODY:          ${{ vars.CONVERSATIONS_BODY }}
       # alert threshold in minutes (adjust as needed)
-      SLA_MINUTES: "15"
+      SLA_MINUTES: "5"
       # Turn on verbose logs for one run; remove later if noisy
       DEBUG: "1"
       # process this many conversations per run while tuning


### PR DESCRIPTION
## Summary
- Support CONVERSATION_LINK_TEMPLATE and CONV_URL_TEMPLATE in cron.mjs
- Fall back to shared builder in lib/email.js when no template is provided
- Append "Link:" line to alert body when available
- Update workflow SLA_MINUTES from 15 to 5

## Testing
- `node --check cron.mjs`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1a00336a0832a89ea81430194e33d