### PR TITLE
feat: build SLA pool from newest messages with dedupe watermark

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 BOOM_API_BASE=https://api.boom.example
 BOOM_API_TOKEN=your-token
 BOOM_ORG_ID=your-org-id
+POOL_SIZE=50
+POOL_TOLERANCE_MS=120000
 # (Optional) CHECK_BATCH_SIZE=50  # if you still batch downstream processing

--- a/cron.mjs
+++ b/cron.mjs
@@ -360,9 +360,8 @@ for (const { id } of toCheck) {
         `ALERT: conv=${id} guest_unanswered=${ageMin}m > ${SLA_MIN}m -> email ${mask(to) || "(no recipient set)"}${convUrl ? ` link=${convUrl}` : ""}`
       );
 
-      // simple dedupe by conversation + last update timestamp
-      const updatedAt = conv?.updated_at || conv?.updatedAt || null;
-      const { dup, state } = isDuplicateAlert(id, updatedAt);
+      // simple dedupe by conversation + last guest message timestamp
+      const { dup, state } = isDuplicateAlert(id, lastGuestMs);
       if (dup) {
         log(`conv ${id}: duplicate alert suppressed`);
       } else {
@@ -375,7 +374,7 @@ for (const { id } of toCheck) {
 Conversation: ${id}${convUrl ? `\nLink: ${convUrl}` : "" }
 Please follow up.`,
           });
-          markAlerted(state, id, updatedAt);
+          markAlerted(state, id, lastGuestMs);
           alerted++;
         } catch (e) {
           console.warn(`conv ${id}: failed to send alert:`, e?.message || e);

--- a/dedupe.mjs
+++ b/dedupe.mjs
@@ -33,17 +33,15 @@ export function saveState(state) {
   }
 }
 
-export function isDuplicateAlert(id, updatedAt) {
+export function isDuplicateAlert(id, lastGuestTs) {
+  const key = `${id}:${lastGuestTs || ''}`;
   const state = loadState();
-  const entry = state[id];
-  if (!entry) return { dup: false, state };
-  if (!updatedAt) return { dup: true, state };
-  const prev = entry.lastUpdatedAt ? new Date(entry.lastUpdatedAt).getTime() : 0;
-  const curr = new Date(updatedAt).getTime();
-  return { dup: prev >= curr, state };
+  const entry = state[key];
+  return { dup: Boolean(entry), state };
 }
 
-export function markAlerted(state, id, updatedAt) {
-  state[id] = { lastUpdatedAt: updatedAt || null, ts: new Date().toISOString() };
+export function markAlerted(state, id, lastGuestTs) {
+  const key = `${id}:${lastGuestTs || ''}`;
+  state[key] = { lastUpdatedAt: lastGuestTs || null, ts: new Date().toISOString() };
   saveState(state);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,17 @@
-import { getTop50PlatformWide } from "./fetchConversations";
+import { buildPoolFromMessages, PoolItem } from "./pool/fromMessages";
 
 // Placeholder for existing SLA check implementation
-async function checkSLA(conversations: any[]) {
+async function checkSLA(pool: PoolItem[]) {
   // existing SLA checks proceed unchanged
 }
 
 async function run() {
-  // Already the objective platform-wide latest 50 from the server:
-  const conversations = await getTop50PlatformWide();
+  const target = Number(process.env.POOL_SIZE ?? 50);
+  const pool = await buildPoolFromMessages(target);
+  console.log(`processing up to ${target} newest global convos by guest msg (actual: ${pool.length})`);
 
   // existing SLA checks proceed unchanged:
-  await checkSLA(conversations);
+  await checkSLA(pool);
 }
 
 run().catch(err => {

--- a/src/pool/fromMessages.ts
+++ b/src/pool/fromMessages.ts
@@ -1,0 +1,67 @@
+import { listMessagesPage } from "../services/messages";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+export type PoolItem = { convId: string; lastGuestTs: number };
+
+function isGuestMessage(m: any): boolean {
+  // adapt to your schema; keep it strict
+  return m?.senderRole === "guest" || m?.direction === "inbound" || m?.from === "guest";
+}
+function tsFromMessage(m: any): number {
+  return Number(m?.timestamp || m?.createdAt || m?.date || 0);
+}
+
+function readWatermark(): number | undefined {
+  const p = join(".state", "lastProcessedMessageTs.json");
+  if (!existsSync(p)) return undefined;
+  try {
+    return JSON.parse(readFileSync(p, "utf8"))?.lastProcessedMessageTs;
+  } catch {
+    return undefined;
+  }
+}
+function writeWatermark(ts: number) {
+  const dir = ".state";
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "lastProcessedMessageTs.json"), JSON.stringify({ lastProcessedMessageTs: ts }), "utf8");
+}
+
+export async function buildPoolFromMessages(target = Number(process.env.POOL_SIZE ?? 50)) {
+  const seen = new Set<string>();
+  const pool: PoolItem[] = [];
+
+  const tolerance = Number(process.env.POOL_TOLERANCE_MS ?? 120000);
+  const watermark = readWatermark();
+  const since = watermark ? Math.max(0, watermark - tolerance) : undefined;
+
+  let cursor: string | undefined = undefined;
+  let maxSeenTs = watermark ?? 0;
+
+  do {
+    const page = await listMessagesPage({ order: "desc", cursor, since }); // must return { items, nextCursor }
+    for (const m of page.items ?? []) {
+      const convId = m?.conversationId ?? m?.conversation_id;
+      const ts = tsFromMessage(m);
+      if (ts > maxSeenTs) maxSeenTs = ts;
+
+      if (!convId || !isGuestMessage(m)) continue;
+      if (seen.has(convId)) continue;
+
+      seen.add(convId);
+      pool.push({ convId, lastGuestTs: ts });
+
+      if (pool.length >= target) break;
+    }
+    if (pool.length >= target) break;
+    cursor = (page as any).nextCursor;
+  } while (cursor);
+
+  // newest by guest activity
+  pool.sort((a, b) => b.lastGuestTs - a.lastGuestTs);
+
+  // advance watermark even if we found < target (prevents misses)
+  if (maxSeenTs) writeWatermark(maxSeenTs);
+
+  return pool;
+}

--- a/src/services/messages.ts
+++ b/src/services/messages.ts
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+const BASE  = process.env.BOOM_API_BASE!;
+const TOKEN = process.env.BOOM_API_TOKEN!;
+const ORG_ID = process.env.BOOM_ORG_ID!;
+
+export async function listMessagesPage(params: { order: "asc" | "desc"; cursor?: string; since?: number }) {
+  const { order, cursor, since } = params;
+  const res = await axios.get(`${BASE}/orgs/${ORG_ID}/messages`, {
+    params: { order, cursor, since },
+    headers: { Authorization: `Bearer ${TOKEN}` },
+    timeout: 15000,
+  });
+  const items = res.data.items ?? res.data ?? [];
+  const nextCursor = res.data.nextCursor ?? res.data.next_cursor;
+  return { items, nextCursor };
+}


### PR DESCRIPTION
## Summary
- add message-based pool builder with watermark and tolerance
- log processing of newest conversations and support configurable pool size
- dedupe alerts by conversation and last guest message timestamp

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c1e9c9e15c832aab33da267a1080ed