### PR TITLE
feat(dedupe): track alerts by conversation and last guest timestamp

### DIFF
--- a/cron.mjs
+++ b/cron.mjs
@@ -2,7 +2,7 @@
 import { spawn } from "node:child_process";
 import nodemailer from "nodemailer";
 import translate from "@vitalets/google-translate-api";
-import { isDuplicateAlert, markAlerted } from "./dedupe.mjs";
+import { isDuplicateAlert, markAlerted, dedupeKey } from "./dedupe.mjs";
 import { selectTop50, assertTop50 } from "./src/lib/selectTop50.js";
 import { buildConversationLink as _buildConversationLink } from "./lib/email.js";
 
@@ -365,6 +365,7 @@ for (const { id } of toCheck) {
       if (dup) {
         log(`conv ${id}: duplicate alert suppressed`);
       } else {
+        const key = dedupeKey(id, lastGuestMs);
         try {
           await sendAlertEmail({
             to,
@@ -375,6 +376,7 @@ Conversation: ${id}${convUrl ? `\nLink: ${convUrl}` : "" }
 Please follow up.`,
           });
           markAlerted(state, id, lastGuestMs);
+          log(`dedupe_key=${key}`);
           alerted++;
         } catch (e) {
           console.warn(`conv ${id}: failed to send alert:`, e?.message || e);

--- a/dedupe.mjs
+++ b/dedupe.mjs
@@ -33,15 +33,19 @@ export function saveState(state) {
   }
 }
 
-export function isDuplicateAlert(id, lastGuestTs) {
-  const key = `${id}:${lastGuestTs || ''}`;
+export function dedupeKey(convId, lastGuestTs) {
+  return `${convId}:${lastGuestTs ?? ''}`;
+}
+
+export function isDuplicateAlert(convId, lastGuestTs) {
+  const key = dedupeKey(convId, lastGuestTs);
   const state = loadState();
-  const entry = state[key];
+  const entry = state[key] || state[convId];
   return { dup: Boolean(entry), state };
 }
 
-export function markAlerted(state, id, lastGuestTs) {
-  const key = `${id}:${lastGuestTs || ''}`;
+export function markAlerted(state, convId, lastGuestTs) {
+  const key = dedupeKey(convId, lastGuestTs);
   state[key] = { lastUpdatedAt: lastGuestTs || null, ts: new Date().toISOString() };
   saveState(state);
 }


### PR DESCRIPTION
## Summary
- dedupe alerts using convId:lastGuestTs composite key via new `dedupeKey`
- update alert scripts to pass last guest timestamp and log `dedupe_key`
- fall back to legacy convId entries for one-time back-compat

## Testing
- `node --check dedupe.mjs`
- `node --check check.mjs`
- `node --check cron.mjs`
- `npx playwright test` *(fails: Need to install the following packages: playwright@1.55.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ebd1db68832aabd7a21fbe00c879