### PR TITLE
fix(redirect): make /r/conversation/[id] a server-side redirect to /inbox/conversations/[id]

### DIFF
--- a/app/r/conversation/[id]/page.tsx
+++ b/app/r/conversation/[id]/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function Page({ params }: { params: { id: string } }) {
+  redirect(`/inbox/conversations/${encodeURIComponent(params.id)}`);
+}


### PR DESCRIPTION
## Summary
- redirect `/r/conversation/[id]` to `/inbox/conversations/[id]`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx playwright test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fbdb7a90832aa40b58ea39edf807