### PR TITLE
Handle legacy conversation URLs

### DIFF
--- a/app/conversations/[id]/page.tsx
+++ b/app/conversations/[id]/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function Page({ params }: { params: { id: string } }) {
+  redirect(`/inbox/conversations/${encodeURIComponent(params.id)}`);
+}

--- a/app/conversations/[id]/route.ts
+++ b/app/conversations/[id]/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server.js';
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  return NextResponse.redirect(new URL(`/inbox/conversations/${params.id}`, req.url), { status: 307 });
+}

--- a/tests/conversation-link.spec.ts
+++ b/tests/conversation-link.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { buildConversationLink } from "../lib/email.js";
 import { GET as convoRoute } from "../app/r/conversation/[id]/route";
+import { GET as legacyConvRoute } from "../app/conversations/[id]/route";
 
 test("buildConversationLink uses UI conversations URL", () => {
   const url = buildConversationLink("123456");
@@ -12,6 +13,17 @@ test("legacy /r/conversation/:id redirects to /inbox", async () => {
     "https://app.boomnow.com/r/conversation/123456"
   );
   const res = await convoRoute(req, { params: { id: "123456" } });
+  expect(res.status).toBe(307);
+  expect(res.headers.get("location")).toBe(
+    "https://app.boomnow.com/inbox/conversations/123456"
+  );
+});
+
+test("legacy /conversations/:id redirects to /inbox", async () => {
+  const req = new Request(
+    "https://app.boomnow.com/conversations/123456"
+  );
+  const res = await legacyConvRoute(req, { params: { id: "123456" } });
   expect(res.status).toBe(307);
   expect(res.headers.get("location")).toBe(
     "https://app.boomnow.com/inbox/conversations/123456"


### PR DESCRIPTION
## Summary
- Redirect old `/conversations/:id` links to the new `/inbox/conversations/:id` path
- Cover legacy `/conversations/:id` links with tests

## Testing
- `npx playwright test tests/conversation-link.spec.ts`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c3cd4f9c9c832a956c7d92d69be243