### PR TITLE
feat: use dashboard conversation deep links

### DIFF
--- a/lib/links.js
+++ b/lib/links.js
@@ -1,7 +1,10 @@
 export function conversationLink(conversation) {
   const base = process.env.APP_URL ?? 'https://app.boomnow.com';
   const idOrUuid = conversation?.uuid ?? conversation?.id;
-  return `${base}/c/${encodeURIComponent(String(idOrUuid))}`;
+  // Link directly to the dashboard deep link to avoid relying on the `/c/:id`
+  // redirect and any legacy numeric-id→UUID lookup. This ensures alert emails
+  // always open the conversation, whether we have a UUID or a numeric ID.
+  return `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(String(idOrUuid))}`;
 }
 export function conversationIdDisplay(c) {
   return c?.uuid ?? c?.id;

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -1,7 +1,7 @@
 export function conversationLink(conversation: { uuid?: string; id?: number }) {
   const base = process.env.APP_URL ?? 'https://app.boomnow.com';
   const idOrUuid = (conversation?.uuid ?? conversation?.id);
-  return `${base}/c/${encodeURIComponent(String(idOrUuid))}`;
+  return `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(String(idOrUuid))}`;
 }
 export function conversationIdDisplay(c: { uuid?: string; id?: number }) {
   return (c?.uuid ?? c?.id) as string | number;

--- a/tests/conversation-link.spec.ts
+++ b/tests/conversation-link.spec.ts
@@ -7,10 +7,12 @@ import { prisma } from "../lib/db";
 
 const uuid = "123e4567-e89b-12d3-a456-426614174000";
 
-test("conversationLink uses universal conversation URL", () => {
+test("conversationLink uses dashboard deep link", () => {
   const url = conversationLink({ uuid });
   expect(url).toBe(
-    `https://app.boomnow.com/c/${encodeURIComponent(uuid)}`
+    `https://app.boomnow.com/dashboard/guest-experience/all?conversation=${encodeURIComponent(
+      uuid
+    )}`
   );
 });
 


### PR DESCRIPTION
## Summary
- link conversations directly to dashboard deep link rather than /c/:id redirect
- update tests for new conversation links

## Testing
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_68c4208d607c832a893819334335dc49