### PR TITLE
Use dashboard deep link for conversations

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,10 +5,10 @@ export function middleware(req: NextRequest) {
   const u = new URL(req.url);
   if (u.pathname === '/inbox' && u.searchParams.has('cid')) {
     const cid = u.searchParams.get('cid')!;
-    return NextResponse.redirect(new URL(`/c/${cid}`, u.origin), 308);
+    return NextResponse.redirect(new URL(`/dashboard/guest-experience/all?conversation=${cid}`, u.origin), 308);
   }
   const m = u.pathname.match(/^\/inbox\/conversations\/([^/]+)$/);
-  if (m) return NextResponse.redirect(new URL(`/c/${m[1]}`, u.origin), 308);
+  if (m) return NextResponse.redirect(new URL(`/dashboard/guest-experience/all?conversation=${m[1]}`, u.origin), 308);
   return NextResponse.next();
 }
 

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -10,7 +10,7 @@ test('GET /inbox/conversations/123 -> 308 /c/123', async () => {
   const res = await middleware(req);
   expect(res.status).toBe(308);
   expect(res.headers.get('location')).toBe(
-    'https://app.boomnow.com/c/123'
+    'https://app.boomnow.com/dashboard/guest-experience/all?conversation=123'
   );
 });
 
@@ -19,7 +19,7 @@ test('middleware redirects legacy /inbox?cid=uuid to /c', async () => {
   const res = await middleware(req);
   expect(res.status).toBe(308);
   expect(res.headers.get('location')).toBe(
-    `https://app.boomnow.com/c/${uuid}`
+    `https://app.boomnow.com/dashboard/guest-experience/all?conversation=${uuid}`
   );
 });
 

--- a/tests/conversation-link.spec.ts
+++ b/tests/conversation-link.spec.ts
@@ -17,7 +17,7 @@ test("conversationLink uses dashboard deep link", () => {
 });
 
 test("/c/:id redirects to dashboard", async () => {
-  const req = new Request(`https://app.boomnow.com/c/${uuid}`);
+  const req = new Request(`https://app.boomnow.com/dashboard/guest-experience/all?conversation=${uuid}`);
   const res = await cRoute(req, { params: { id: uuid } });
   expect(res.status).toBe(308);
   expect(res.headers.get("location")).toBe(
@@ -27,7 +27,7 @@ test("/c/:id redirects to dashboard", async () => {
 
 test("/c/:id resolves legacy numeric id", async () => {
   prisma.conversation.findUnique = async () => ({ uuid });
-  const req = new Request(`https://app.boomnow.com/c/123`);
+  const req = new Request(`https://app.boomnow.com/dashboard/guest-experience/all?conversation=123`);
   const res = await cRoute(req, { params: { id: "123" } });
   expect(res.status).toBe(308);
   expect(res.headers.get("location")).toBe(


### PR DESCRIPTION
## Summary
- Update middleware and tests to use dashboard deep link for conversations instead of legacy /c/:id paths
- Remove accidentally committed backup files

## Testing
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_68c42832a700832aba1339ae3f3e11f6