### PR TITLE
Fix broken conversation links for numeric IDs; add defensive redirect in dashboard

### DIFF
--- a/app/dashboard/guest-experience/all/page.tsx
+++ b/app/dashboard/guest-experience/all/page.tsx
@@ -1,10 +1,18 @@
+import { redirect } from 'next/navigation';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 export default function Page({ searchParams }: { searchParams: { conversation?: string } }) {
   const conversation =
     typeof searchParams.conversation === 'string' && searchParams.conversation.length > 0
       ? searchParams.conversation
       : undefined;
 
-  // Placeholder component to avoid build issues; replace with real implementation.
+  if (conversation && !UUID_RE.test(conversation)) {
+    redirect(`/c/${encodeURIComponent(conversation)}`);
+  }
+
   return <GuestExperience initialConversationId={conversation} />;
 }
 

--- a/lib/links.js
+++ b/lib/links.js
@@ -1,10 +1,14 @@
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 export function conversationLink(conversation) {
   const base = process.env.APP_URL ?? 'https://app.boomnow.com';
-  const idOrUuid = conversation?.uuid ?? conversation?.id;
-  // Link directly to the dashboard deep link to avoid relying on the `/c/:id`
-  // redirect and any legacy numeric-id→UUID lookup. This ensures alert emails
-  // always open the conversation, whether we have a UUID or a numeric ID.
-  return `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(String(idOrUuid))}`;
+  const idOrUuid = String(conversation?.uuid ?? conversation?.id ?? '');
+  if (!idOrUuid)
+    return `${base}/dashboard/guest-experience/all`;
+  return UUID_RE.test(idOrUuid)
+    ? `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(idOrUuid)}`
+    : `${base}/c/${encodeURIComponent(idOrUuid)}`;
 }
 export function conversationIdDisplay(c) {
   return c?.uuid ?? c?.id;

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -1,7 +1,16 @@
-export function conversationLink(conversation: { uuid?: string; id?: number }) {
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function conversationLink(
+  conversation: { id?: number | string; uuid?: string } | null | undefined
+) {
   const base = process.env.APP_URL ?? 'https://app.boomnow.com';
-  const idOrUuid = (conversation?.uuid ?? conversation?.id);
-  return `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(String(idOrUuid))}`;
+  const idOrUuid = String(conversation?.uuid ?? conversation?.id ?? '');
+  if (!idOrUuid)
+    return `${base}/dashboard/guest-experience/all`;
+  return UUID_RE.test(idOrUuid)
+    ? `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(idOrUuid)}`
+    : `${base}/c/${encodeURIComponent(idOrUuid)}`;
 }
 export function conversationIdDisplay(c: { uuid?: string; id?: number }) {
   return (c?.uuid ?? c?.id) as string | number;

--- a/tests/conversation-link.spec.ts
+++ b/tests/conversation-link.spec.ts
@@ -16,6 +16,11 @@ test("conversationLink uses dashboard deep link", () => {
   );
 });
 
+test("conversationLink uses resolver for numeric id", () => {
+  const url = conversationLink({ id: 994018 });
+  expect(url).toBe(`https://app.boomnow.com/c/994018`);
+});
+
 test("/c/:id redirects to dashboard", async () => {
   const req = new Request(`https://app.boomnow.com/dashboard/guest-experience/all?conversation=${uuid}`);
   const res = await cRoute(req, { params: { id: uuid } });


### PR DESCRIPTION
## Summary
- Route numeric conversation IDs through `/c/:id`; deep-link only for UUIDs
- Redirect dashboard requests with non-UUID conversation params to `/c/:id`
- Add test covering numeric conversation ID links

## Testing
- `pnpm install`
- `pnpm test` *(fails: Missing script: test)*
- `pnpm exec playwright test`
- `pnpm build` *(fails: Command "build" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c454433cf8832a883d3fa39cd9c9af