### PR TITLE
Fix: durable conversation links and slug support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ POOL_TOLERANCE_MS=120000
 # (Optional) CHECK_BATCH_SIZE=50  # if you still batch downstream processing
 AUTH_SECRET=replace-with-strong-random-string
 CONVERSATION_LINK_TEMPLATE=https://app.boomnow.com/inbox/conversations/{id}
+APP_URL=https://app.boomnow.com

--- a/app/c/[id]/route.ts
+++ b/app/c/[id]/route.ts
@@ -4,24 +4,23 @@ import type { NextRequest } from 'next/server.js';
 // TODO: replace with your real DB access
 import { prisma } from '../../../lib/db'; // or whatever you use
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   const { id } = params;
 
-  // If it's already a UUID → redirect directly
+  // If already a UUID → redirect directly to dashboard with query param
   if (UUID_RE.test(id)) {
     const to = new URL('/dashboard/guest-experience/all', req.url);
     to.searchParams.set('conversation', id);
     return NextResponse.redirect(to, 308);
   }
 
-  // If it's numeric → look up the UUID, then redirect
-  const legacy = Number(id);
-  if (Number.isFinite(legacy)) {
-    // Adjust to your schema: legacy numeric id -> uuid
-    const conv = await prisma.conversation.findUnique({
-      where: { legacyId: legacy },
+  // If numeric legacy id → existing lookup flow
+  if (!Number.isNaN(Number(id))) {
+    const conv = await prisma.conversation.findFirst({
+      where: { legacyId: Number(id) },
       select: { uuid: true },
     });
     if (conv?.uuid) {
@@ -31,8 +30,20 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
     }
   }
 
+  // NEW: handle slugs / external ids / public ids
+  const conv = await prisma.conversation.findFirst({
+    where: {
+      OR: [{ externalId: id }, { publicId: id }, { slug: id }],
+    },
+    select: { uuid: true },
+  });
+  if (conv?.uuid) {
+    const to = new URL('/dashboard/guest-experience/all', req.url);
+    to.searchParams.set('conversation', conv.uuid);
+    return NextResponse.redirect(to, 308);
+  }
+
   // Fallback: land on dashboard without a conversation selected
-  const fallback = new URL('/dashboard/guest-experience/all', req.url);
-  fallback.searchParams.set('notice', 'conversation_not_found');
-  return NextResponse.redirect(fallback, 307);
+  const to = new URL('/dashboard/guest-experience/all', req.url);
+  return NextResponse.redirect(to, 308);
 }

--- a/app/r/conversation/[id]/route.ts
+++ b/app/r/conversation/[id]/route.ts
@@ -1,7 +1,33 @@
 import { NextResponse } from 'next/server.js';
 
+// TODO: replace with your real DB access
+import { prisma } from '../../../../lib/db';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 export async function GET(req: Request, { params }: { params: { id: string } }) {
-  const url = new URL('/dashboard/guest-experience/all', req.url);
-  url.searchParams.set('conversation', params.id);
-  return NextResponse.redirect(url, { status: 307 });
+  const { id } = params;
+
+  let uuid = UUID_RE.test(id) ? id : undefined;
+
+  if (!uuid) {
+    if (!Number.isNaN(Number(id))) {
+      const conv = await prisma.conversation.findFirst({
+        where: { legacyId: Number(id) },
+        select: { uuid: true },
+      });
+      uuid = conv?.uuid;
+    } else {
+      const conv = await prisma.conversation.findFirst({
+        where: { OR: [{ externalId: id }, { publicId: id }, { slug: id }] },
+        select: { uuid: true },
+      });
+      uuid = conv?.uuid;
+    }
+  }
+
+  const to = new URL('/dashboard/guest-experience/all', req.url);
+  if (uuid) to.searchParams.set('conversation', uuid);
+  return NextResponse.redirect(to, 308);
 }

--- a/lib/links.js
+++ b/lib/links.js
@@ -1,14 +1,9 @@
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
 export function conversationLink(conversation) {
   const base = process.env.APP_URL ?? 'https://app.boomnow.com';
   const idOrUuid = String(conversation?.uuid ?? conversation?.id ?? '');
-  if (!idOrUuid)
-    return `${base}/dashboard/guest-experience/all`;
-  return UUID_RE.test(idOrUuid)
-    ? `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(idOrUuid)}`
-    : `${base}/c/${encodeURIComponent(idOrUuid)}`;
+  if (!idOrUuid) return `${base}/dashboard/guest-experience/all`;
+  // Always use a path-based redirector so email trackers cannot drop query params.
+  return `${base}/r/conversation/${encodeURIComponent(idOrUuid)}`;
 }
 export function conversationIdDisplay(c) {
   return c?.uuid ?? c?.id;

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -1,16 +1,11 @@
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
 export function conversationLink(
   conversation: { id?: number | string; uuid?: string } | null | undefined
 ) {
   const base = process.env.APP_URL ?? 'https://app.boomnow.com';
   const idOrUuid = String(conversation?.uuid ?? conversation?.id ?? '');
-  if (!idOrUuid)
-    return `${base}/dashboard/guest-experience/all`;
-  return UUID_RE.test(idOrUuid)
-    ? `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(idOrUuid)}`
-    : `${base}/c/${encodeURIComponent(idOrUuid)}`;
+  if (!idOrUuid) return `${base}/dashboard/guest-experience/all`;
+  // Always use a path-based redirector so email trackers cannot drop query params.
+  return `${base}/r/conversation/${encodeURIComponent(idOrUuid)}`;
 }
 export function conversationIdDisplay(c: { uuid?: string; id?: number }) {
   return (c?.uuid ?? c?.id) as string | number;


### PR DESCRIPTION
## Summary
- use path-based /r/conversation redirect for conversation links
- allow `/c/:id` and `/r/conversation/:id` to resolve numeric IDs and slugs to UUIDs
- document APP_URL in example env

## Testing
- `npx tsc --noEmit`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_68c45b7ebd30832a8d4a12d2d81dbe97