### PR TITLE
Fix dashboard conversation links

### DIFF
--- a/app/c/[id]/route.ts
+++ b/app/c/[id]/route.ts
@@ -3,7 +3,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const dash = (v?: string) => {
-    const u = new URL('/dashboard/guest-experience/all', req.url);
+    const u = new URL('/dashboard/guest-experience/cs', req.url);
     if (v) u.searchParams.set('conversation', v);
     return u;
   };

--- a/app/conversations/[id]/page.tsx
+++ b/app/conversations/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation.js";
 
 export default function Page({ params }: { params: { id: string } }) {
-  const url = `/dashboard/guest-experience/all?conversation=${encodeURIComponent(params.id)}`;
+  const url = `/dashboard/guest-experience/cs?conversation=${encodeURIComponent(params.id)}`;
   redirect(url);
 }

--- a/app/conversations/[id]/route.ts
+++ b/app/conversations/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server.js';
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
-  const url = new URL('/dashboard/guest-experience/all', req.url);
+  const url = new URL('/dashboard/guest-experience/cs', req.url);
   url.searchParams.set('conversation', params.id);
   return NextResponse.redirect(url, { status: 307 });
 }

--- a/app/inbox/conversations/[id]/page.tsx
+++ b/app/inbox/conversations/[id]/page.tsx
@@ -2,6 +2,6 @@ import { redirect } from 'next/navigation.js';
 
 // Redirect legacy /inbox/conversations/:id links to the dashboard deep link.
 export default function ConversationPage({ params }: { params: { id: string } }) {
-  const dest = `/dashboard/guest-experience/all?conversation=${encodeURIComponent(params.id)}`;
+  const dest = `/dashboard/guest-experience/cs?conversation=${encodeURIComponent(params.id)}`;
   redirect(dest);
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 
 export default function Home() {
   useEffect(() => {
-    const to = '/dashboard/guest-experience/all';
+    const to = '/dashboard/guest-experience/cs';
     if (location.pathname !== to) location.replace(to);
   }, []);
   return <p>Redirecting…</p>;

--- a/app/r/conversation/[id]/route.ts
+++ b/app/r/conversation/[id]/route.ts
@@ -42,7 +42,7 @@ async function toUuid(id: string) {
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const origin = process.env.APP_URL ?? new URL(req.url).origin;
   const uuid = await toUuid(params.id);
-  const to = new URL('/dashboard/guest-experience/all', origin);
+  const to = new URL('/dashboard/guest-experience/cs', origin);
   if (uuid) to.searchParams.set('conversation', uuid);
 
   const href = to.toString();

--- a/lib/links.js
+++ b/lib/links.js
@@ -2,8 +2,8 @@ export function conversationLink(c) {
   const base = process.env.APP_URL ?? 'https://app.boomnow.com';
   const v = String(c?.uuid ?? c?.id ?? '');
   return v
-    ? `${base}/r/conversation/${encodeURIComponent(v)}`
-    : `${base}/dashboard/guest-experience/all`;
+    ? `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(v)}`
+    : `${base}/dashboard/guest-experience/cs`;
 }
 export function conversationIdDisplay(c) {
   return c?.uuid ?? c?.id;

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -2,8 +2,8 @@ export function conversationLink(c?: { id?: number | string; uuid?: string } | n
   const base = process.env.APP_URL ?? 'https://app.boomnow.com';
   const v = String(c?.uuid ?? c?.id ?? '');
   return v
-    ? `${base}/r/conversation/${encodeURIComponent(v)}`
-    : `${base}/dashboard/guest-experience/all`;
+    ? `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(v)}`
+    : `${base}/dashboard/guest-experience/cs`;
 }
 
 export function conversationIdDisplay(c: { uuid?: string; id?: number }) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -10,7 +10,7 @@ export function middleware(req: Request) {
   if (path === '/inbox' && url.searchParams.has('cid')) {
     const cid = url.searchParams.get('cid')!;
     return NextResponse.redirect(
-      new URL(`/dashboard/guest-experience/all?conversation=${cid}`, url.origin),
+      new URL(`/dashboard/guest-experience/cs?conversation=${cid}`, url.origin),
       308,
     );
   }
@@ -18,7 +18,7 @@ export function middleware(req: Request) {
   const m = path.match(/^\/inbox\/conversations\/([^/]+)$/);
   if (m)
     return NextResponse.redirect(
-      new URL(`/dashboard/guest-experience/all?conversation=${m[1]}`, url.origin),
+      new URL(`/dashboard/guest-experience/cs?conversation=${m[1]}`, url.origin),
       308,
     );
 

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -10,7 +10,7 @@ test('GET /inbox/conversations/123 -> 308 /c/123', async () => {
   const res = await middleware(req);
   expect(res.status).toBe(308);
   expect(res.headers.get('location')).toBe(
-    'https://app.boomnow.com/dashboard/guest-experience/all?conversation=123'
+    'https://app.boomnow.com/dashboard/guest-experience/cs?conversation=123'
   );
 });
 
@@ -19,12 +19,12 @@ test('middleware redirects legacy /inbox?cid=uuid to /c', async () => {
   const res = await middleware(req);
   expect(res.status).toBe(308);
   expect(res.headers.get('location')).toBe(
-    `https://app.boomnow.com/dashboard/guest-experience/all?conversation=${uuid}`
+    `https://app.boomnow.com/dashboard/guest-experience/cs?conversation=${uuid}`
   );
 });
 
 test('POST /api/login with next=dashboard link -> 303 to that path', async () => {
-  const next = `/dashboard/guest-experience/all?conversation=${uuid}`;
+  const next = `/dashboard/guest-experience/cs?conversation=${uuid}`;
   const body = new URLSearchParams({
     email: 'test@example.com',
     password: 'x',

--- a/tests/conversation-link.spec.ts
+++ b/tests/conversation-link.spec.ts
@@ -8,26 +8,30 @@ import { prisma } from "../lib/db";
 const BASE = process.env.APP_URL ?? "https://app.boomnow.com";
 const uuid = "123e4567-e89b-12d3-a456-426614174000";
 
-test("uses path-based /r for UUID", () => {
-  expect(conversationLink({ uuid })).toBe(`${BASE}/r/conversation/${uuid}`);
+test("builds dashboard link for UUID", () => {
+  expect(conversationLink({ uuid })).toBe(
+    `${BASE}/dashboard/guest-experience/cs?conversation=${uuid}`
+  );
 });
 
-test("uses path-based /r for numeric id", () => {
-  expect(conversationLink({ id: 42 })).toBe(`${BASE}/r/conversation/42`);
+test("builds dashboard link for numeric id", () => {
+  expect(conversationLink({ id: 42 })).toBe(
+    `${BASE}/dashboard/guest-experience/cs?conversation=42`
+  );
 });
 
 test("falls back to dashboard when missing", () => {
   expect(conversationLink(undefined)).toBe(
-    `${BASE}/dashboard/guest-experience/all`
+    `${BASE}/dashboard/guest-experience/cs`
   );
 });
 
 test("/c/:id redirects UUID directly", async () => {
-  const req = new Request(`${BASE}/dashboard/guest-experience/all?conversation=${uuid}`);
+  const req = new Request(`${BASE}/dashboard/guest-experience/cs?conversation=${uuid}`);
   const res = await cRoute(req as any, { params: { id: uuid } });
   expect(res.status).toBe(302);
   expect(res.headers.get("location")).toBe(
-    `${BASE}/dashboard/guest-experience/all?conversation=${uuid}`
+    `${BASE}/dashboard/guest-experience/cs?conversation=${uuid}`
   );
 });
 
@@ -37,7 +41,7 @@ test("/c/:id resolves legacy numeric id", async () => {
   const res = await cRoute(req as any, { params: { id: "123" } });
   expect(res.status).toBe(302);
   expect(res.headers.get("location")).toBe(
-    `${BASE}/dashboard/guest-experience/all?conversation=${uuid}`
+    `${BASE}/dashboard/guest-experience/cs?conversation=${uuid}`
   );
 });
 
@@ -47,7 +51,7 @@ test("/c/:id resolves slug", async () => {
   const res = await cRoute(req as any, { params: { id: "sluggy" } });
   expect(res.status).toBe(302);
   expect(res.headers.get("location")).toBe(
-    `${BASE}/dashboard/guest-experience/all?conversation=${uuid}`
+    `${BASE}/dashboard/guest-experience/cs?conversation=${uuid}`
   );
 });
 
@@ -57,10 +61,10 @@ test("/r/conversation/:id serves HTML redirector", async () => {
   expect(res.status).toBe(200);
   const text = await res.text();
   expect(text).toContain(
-    `<meta http-equiv="refresh" content="0; url=${BASE}/dashboard/guest-experience/all?conversation=${uuid}">`
+    `<meta http-equiv="refresh" content="0; url=${BASE}/dashboard/guest-experience/cs?conversation=${uuid}">`
   );
   expect(text).toContain(
-    `<a href="${BASE}/dashboard/guest-experience/all?conversation=${uuid}" rel="nofollow">`
+    `<a href="${BASE}/dashboard/guest-experience/cs?conversation=${uuid}" rel="nofollow">`
   );
 });
 
@@ -69,7 +73,7 @@ test("legacy /conversations/:id redirects to dashboard", async () => {
   const res = await legacyConvRoute(req, { params: { id: uuid } });
   expect(res.status).toBe(307);
   expect(res.headers.get("location")).toBe(
-    `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`
+    `${BASE}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(uuid)}`
   );
 });
 


### PR DESCRIPTION
## Summary
- point conversation links directly to `/dashboard/guest-experience/cs` path
- update redirect routes and middleware for new conversation URL
- adjust tests for new link format

## Testing
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_68c4705cef5c832a8497e2b5182c2acc