### PR TITLE
Use redirector for conversation links

### DIFF
--- a/lib/links.js
+++ b/lib/links.js
@@ -2,7 +2,7 @@ export function conversationLink(c) {
   const base = process.env.APP_URL ?? 'https://app.boomnow.com';
   const v = String(c?.uuid ?? c?.id ?? '');
   return v
-    ? `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(v)}`
+    ? `${base}/r/conversation/${encodeURIComponent(v)}`
     : `${base}/dashboard/guest-experience/cs`;
 }
 export function conversationIdDisplay(c) {

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -2,7 +2,7 @@ export function conversationLink(c?: { id?: number | string; uuid?: string } | n
   const base = process.env.APP_URL ?? 'https://app.boomnow.com';
   const v = String(c?.uuid ?? c?.id ?? '');
   return v
-    ? `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(v)}`
+    ? `${base}/r/conversation/${encodeURIComponent(v)}`
     : `${base}/dashboard/guest-experience/cs`;
 }
 

--- a/tests/conversation-link.spec.ts
+++ b/tests/conversation-link.spec.ts
@@ -8,15 +8,15 @@ import { prisma } from "../lib/db";
 const BASE = process.env.APP_URL ?? "https://app.boomnow.com";
 const uuid = "123e4567-e89b-12d3-a456-426614174000";
 
-test("builds dashboard link for UUID", () => {
+test("builds redirect link for UUID", () => {
   expect(conversationLink({ uuid })).toBe(
-    `${BASE}/dashboard/guest-experience/cs?conversation=${uuid}`
+    `${BASE}/r/conversation/${uuid}`
   );
 });
 
-test("builds dashboard link for numeric id", () => {
+test("builds redirect link for numeric id", () => {
   expect(conversationLink({ id: 42 })).toBe(
-    `${BASE}/dashboard/guest-experience/cs?conversation=42`
+    `${BASE}/r/conversation/42`
   );
 });
 


### PR DESCRIPTION
## Summary
- link conversations via `/r/conversation/:id` redirector
- adjust tests for new redirect URL

## Testing
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_68c47ae1edac832a9b4a007945a313db