### PR TITLE
Fix: redirect guest-experience /cs → /all (preserve query)

### DIFF
--- a/app/dashboard/guest-experience/cs/page.tsx
+++ b/app/dashboard/guest-experience/cs/page.tsx
@@ -1,0 +1,22 @@
+import { redirect } from 'next/navigation';
+
+// Note: Next passes `searchParams` to Server Components at render time.
+export default function Page({
+  searchParams,
+}: {
+  // Support string | string[] | undefined to match Next types.
+  searchParams: Record<string, string | string[] | undefined>;
+}) {
+  // Rebuild the query string while preserving multi-value params.
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(searchParams || {})) {
+    if (Array.isArray(value)) {
+      for (const v of value) params.append(key, v);
+    } else if (value != null) {
+      params.set(key, value);
+    }
+  }
+
+  const qs = params.toString();
+  redirect(`/dashboard/guest-experience/all${qs ? `?${qs}` : ''}`);
+}

--- a/e2e/ge-cs-redirect.spec.ts
+++ b/e2e/ge-cs-redirect.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import next from 'next';
+import http from 'http';
+
+// Start a Next.js server for testing the redirect.
+async function startServer() {
+  const app = next({ dev: true, dir: process.cwd() });
+  const handle = app.getRequestHandler();
+  await app.prepare();
+  const server = http.createServer((req, res) => handle(req, res));
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const port = (server.address() as any).port;
+  return { server, port };
+}
+
+// Ensure the server is closed after the test.
+async function stopServer(server: http.Server) {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+test('legacy /cs route redirects to /all and preserves query', async ({ page }) => {
+  const { server, port } = await startServer();
+  const q = 'conversation=test-123';
+  await page.goto(`http://localhost:${port}/dashboard/guest-experience/cs?${q}`, {
+    waitUntil: 'domcontentloaded',
+  });
+
+  const url = new URL(page.url());
+  expect(url.pathname).toBe('/dashboard/guest-experience/all');
+  expect(url.searchParams.get('conversation')).toBe('test-123');
+
+  await stopServer(server);
+});


### PR DESCRIPTION
## Summary
- add server-side redirect page for legacy /dashboard/guest-experience/cs
- add Playwright test to ensure redirect preserves query string

## Testing
- `pnpm install`
- `pnpm run lint` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `pnpm run test` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*
- `pnpm run build` *(fails: Missing script)*
- `npm run build` *(fails: Missing script)*
- `npx playwright test tests e2e`

------
https://chatgpt.com/codex/tasks/task_e_68c481faf58c832a96cc7ac9d7602bc6