### PR TITLE
fix(links): build dashboard deep link for conversations and redirect legacy routes

### DIFF
--- a/app/c/[id]/route.ts
+++ b/app/c/[id]/route.ts
@@ -3,7 +3,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const dash = (v?: string) => {
-    const u = new URL('/dashboard/guest-experience/cs', req.url);
+    const u = new URL('/dashboard/guest-experience/all', req.url);
     if (v) u.searchParams.set('conversation', v);
     return u;
   };

--- a/app/conversations/[id]/route.ts
+++ b/app/conversations/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server.js';
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
-  const url = new URL('/dashboard/guest-experience/cs', req.url);
+  const url = new URL('/dashboard/guest-experience/all', req.url);
   url.searchParams.set('conversation', params.id);
   return NextResponse.redirect(url, { status: 307 });
 }

--- a/app/inbox/conversations/[id]/page.tsx
+++ b/app/inbox/conversations/[id]/page.tsx
@@ -2,6 +2,6 @@ import { redirect } from 'next/navigation.js';
 
 // Redirect legacy /inbox/conversations/:id links to the dashboard deep link.
 export default function ConversationPage({ params }: { params: { id: string } }) {
-  const dest = `/dashboard/guest-experience/cs?conversation=${encodeURIComponent(params.id)}`;
+  const dest = `/dashboard/guest-experience/all?conversation=${encodeURIComponent(params.id)}`;
   redirect(dest);
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 
 export default function Home() {
   useEffect(() => {
-    const to = '/dashboard/guest-experience/cs';
+    const to = '/dashboard/guest-experience/all';
     if (location.pathname !== to) location.replace(to);
   }, []);
   return <p>Redirecting…</p>;

--- a/app/r/conversation/[id]/route.ts
+++ b/app/r/conversation/[id]/route.ts
@@ -42,7 +42,7 @@ async function toUuid(id: string) {
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const origin = process.env.APP_URL ?? new URL(req.url).origin;
   const uuid = await toUuid(params.id);
-  const to = new URL('/dashboard/guest-experience/cs', origin);
+  const to = new URL('/dashboard/guest-experience/all', origin);
   if (uuid) to.searchParams.set('conversation', uuid);
 
   const href = to.toString();

--- a/lib/links.js
+++ b/lib/links.js
@@ -1,9 +1,13 @@
-export function conversationLink(c) {
-  const base = process.env.APP_URL ?? 'https://app.boomnow.com';
-  const v = String(c?.uuid ?? c?.id ?? '');
-  return v
-    ? `${base}/r/conversation/${encodeURIComponent(v)}`
-    : `${base}/dashboard/guest-experience/cs`;
+export function conversationLink(c, base = process.env.APP_URL ?? 'https://app.boomnow.com') {
+  const raw = typeof c === 'string' ? c : c?.uuid ?? c?.id ?? '';
+  const id = String(raw ?? '').trim();
+  const tmpl = process.env.CONVERSATION_LINK_TEMPLATE ?? '';
+  if (id && tmpl.includes('{id}')) {
+    return tmpl.replace('{id}', encodeURIComponent(id));
+  }
+  return id
+    ? `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(id)}`
+    : `${base}/dashboard/guest-experience/all`;
 }
 export function conversationIdDisplay(c) {
   return c?.uuid ?? c?.id;

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -1,9 +1,16 @@
-export function conversationLink(c?: { id?: number | string; uuid?: string } | null) {
-  const base = process.env.APP_URL ?? 'https://app.boomnow.com';
-  const v = String(c?.uuid ?? c?.id ?? '');
-  return v
-    ? `${base}/r/conversation/${encodeURIComponent(v)}`
-    : `${base}/dashboard/guest-experience/cs`;
+export function conversationLink(
+  c?: { id?: number | string; uuid?: string } | string | null,
+  base = process.env.APP_URL ?? 'https://app.boomnow.com',
+) {
+  const raw = typeof c === 'string' ? c : c?.uuid ?? c?.id ?? '';
+  const id = String(raw ?? '').trim();
+  const tmpl = process.env.CONVERSATION_LINK_TEMPLATE ?? '';
+  if (id && tmpl.includes('{id}')) {
+    return tmpl.replace('{id}', encodeURIComponent(id));
+  }
+  return id
+    ? `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(id)}`
+    : `${base}/dashboard/guest-experience/all`;
 }
 
 export function conversationIdDisplay(c: { uuid?: string; id?: number }) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,6 +4,27 @@ import { NextResponse } from 'next/server.js';
 export function middleware(req: NextRequest) {
   const url = new URL(req.url);
 
+  // Match /inbox?cid=...
+  const cid = url.searchParams.get('cid');
+  if (url.pathname === '/inbox' && cid) {
+    const dest = new URL('/dashboard/guest-experience/all', url);
+    url.searchParams.forEach((v, k) => {
+      if (k !== 'cid') dest.searchParams.append(k, v);
+    });
+    dest.searchParams.set('conversation', cid);
+    return NextResponse.redirect(dest, { status: 308 });
+  }
+
+  // Match /inbox/conversations/:id
+  const inboxMatch = url.pathname.match(/^\/inbox\/conversations\/([^/]+)/);
+  if (inboxMatch) {
+    const id = inboxMatch[1];
+    const dest = new URL('/dashboard/guest-experience/all', url);
+    url.searchParams.forEach((v, k) => dest.searchParams.append(k, v));
+    dest.searchParams.set('conversation', id);
+    return NextResponse.redirect(dest, { status: 308 });
+  }
+
   // Match /r/conversation/:id
   const match = url.pathname.match(/^\/r\/conversation\/([^/]+)/);
   if (match) {
@@ -20,5 +41,5 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/r/conversation/:path*'],
+  matcher: ['/r/conversation/:path*', '/inbox/conversations/:path*', '/inbox'],
 };

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -10,7 +10,7 @@ test('GET /inbox/conversations/123 -> 308 /c/123', async () => {
   const res = await middleware(req);
   expect(res.status).toBe(308);
   expect(res.headers.get('location')).toBe(
-    'https://app.boomnow.com/dashboard/guest-experience/cs?conversation=123'
+    'https://app.boomnow.com/dashboard/guest-experience/all?conversation=123'
   );
 });
 
@@ -19,12 +19,12 @@ test('middleware redirects legacy /inbox?cid=uuid to /c', async () => {
   const res = await middleware(req);
   expect(res.status).toBe(308);
   expect(res.headers.get('location')).toBe(
-    `https://app.boomnow.com/dashboard/guest-experience/cs?conversation=${uuid}`
+    `https://app.boomnow.com/dashboard/guest-experience/all?conversation=${uuid}`
   );
 });
 
 test('POST /api/login with next=dashboard link -> 303 to that path', async () => {
-  const next = `/dashboard/guest-experience/cs?conversation=${uuid}`;
+  const next = `/dashboard/guest-experience/all?conversation=${uuid}`;
   const body = new URLSearchParams({
     email: 'test@example.com',
     password: 'x',


### PR DESCRIPTION
## Summary
- update `conversationLink` to produce `/dashboard/guest-experience/all?conversation=<id>` deep links with optional template override
- redirect legacy inbox and short conversation routes to the new dashboard deep link
- adjust tests for UUID and numeric id coverage

## Testing
- `npx playwright test` *(fails: ENETUNREACH while starting Next server)*

------
https://chatgpt.com/codex/tasks/task_e_68c585fe9404832aa0dcb8c234e20834