### PR TITLE
Improve UUID resolution from inline threads; prevent inlineThread ReferenceError; only send alerts with working deep links

### DIFF
--- a/apps/server/lib/conversations.js
+++ b/apps/server/lib/conversations.js
@@ -1,6 +1,126 @@
 import { isUuid } from '../../shared/lib/uuid.js';
+import { prisma } from '../../../lib/db.js';
 
-export async function tryResolveConversationUuid(idOrUuid, _opts = {}) {
-  const id = String(idOrUuid ?? '');
-  return isUuid(id) ? id.toLowerCase() : null;
+const UUID_RE =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+
+function firstUuid(str) {
+  if (typeof str !== 'string') return null;
+  const m = str.match(UUID_RE);
+  return m ? m[0].toLowerCase() : null;
+}
+
+function* textFields(obj) {
+  if (!obj || typeof obj !== 'object') return;
+  const keys = ['text', 'body', 'html', 'content', 'message', 'snippet', 'subject'];
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === 'string') yield v;
+  }
+}
+
+async function tryUuidFromInlineThread(inlineThread) {
+  if (!inlineThread || typeof inlineThread !== 'object') return null;
+
+  // direct fields
+  const direct =
+    inlineThread.conversation_uuid ||
+    inlineThread.conversationUuid ||
+    inlineThread.uuid ||
+    inlineThread.conversation?.uuid;
+  const directHit = firstUuid(String(direct || ''));
+  if (directHit) return directHit;
+
+  // message arrays we might receive
+  const msgs =
+    (Array.isArray(inlineThread.messages) && inlineThread.messages) ||
+    (Array.isArray(inlineThread.thread) && inlineThread.thread) ||
+    (Array.isArray(inlineThread.items) && inlineThread.items) || [];
+
+  for (const m of msgs) {
+    if (!m || typeof m !== 'object') continue;
+
+    // structured candidates
+    const cands = [
+      m.conversation_uuid,
+      m.conversationUuid,
+      m.thread_uuid,
+      m.uuid,
+      m.conversation?.uuid,
+      m.thread?.uuid,
+    ];
+    for (const c of cands) {
+      const hit = firstUuid(String(c || ''));
+      if (hit) return hit;
+    }
+
+    // urls / bodies containing ?conversation=<uuid> or raw uuid
+    for (const s of textFields(m)) {
+      const q = s.match(/conversation=([0-9a-fA-F-]{36})/);
+      if (q && UUID_RE.test(q[1])) return q[1].toLowerCase();
+      const any = firstUuid(s);
+      if (any) return any;
+    }
+  }
+
+  // numeric/slug ids inside messages → map via DB
+  const idSet = new Set();
+  for (const m of msgs) {
+    const vals = [
+      m?.conversation?.id,
+      m?.conversation_id,
+      m?.meta?.conversation_id,
+      m?.headers?.conversation_id,
+    ].filter(v => v != null);
+    for (const v of vals) idSet.add(String(v));
+  }
+  for (const v of idSet) {
+    if (/^\d+$/.test(v)) {
+      const row = await prisma.conversation.findFirst({
+        where: { legacyId: Number(v) },
+        select: { uuid: true },
+      });
+      if (row?.uuid && isUuid(row.uuid)) return row.uuid.toLowerCase();
+    }
+    const bySlug = await prisma.conversation.findFirst({
+      where: { slug: v },
+      select: { uuid: true },
+    });
+    if (bySlug?.uuid && isUuid(bySlug.uuid)) return bySlug.uuid.toLowerCase();
+  }
+
+  return null;
+}
+
+export async function tryResolveConversationUuid(idOrUuid, opts = {}) {
+  const raw = String(idOrUuid ?? '').trim();
+  if (!raw) return null;
+
+  // 1) already uuid
+  if (isUuid(raw)) return raw.toLowerCase();
+
+  // 2) db lookups (legacy numeric / slug)
+  try {
+    if (prisma?.conversation?.findFirst) {
+      const n = Number(raw);
+      if (Number.isInteger(n)) {
+        const byNum = await prisma.conversation.findFirst({
+          where: { legacyId: n },
+          select: { uuid: true },
+        });
+        if (byNum?.uuid && isUuid(byNum.uuid)) return byNum.uuid.toLowerCase();
+      }
+      const bySlug = await prisma.conversation.findFirst({
+        where: { slug: raw },
+        select: { uuid: true },
+      });
+      if (bySlug?.uuid && isUuid(bySlug.uuid)) return bySlug.uuid.toLowerCase();
+    }
+  } catch { /* ignore, fall through */ }
+
+  // 3) mine inline thread
+  const mined = await tryUuidFromInlineThread(opts.inlineThread);
+  if (mined) return mined;
+
+  return null;
 }

--- a/cron.mjs
+++ b/cron.mjs
@@ -335,7 +335,7 @@ for (const { id } of toCheck) {
 
   // Make inline thread available to the resolver (prevents ReferenceError).
   // We only add keys that the resolver knows how to read.
-  const inlineThread = { messages: Array.isArray(msgs) ? msgs : undefined };
+  const inlineThread = { messages: Array.isArray(msgs) ? msgs : [] }; // ensure in-scope
 
   // Skip very stale threads entirely
   const newestTs = Math.max(...msgs.map(getTs).filter(Boolean));
@@ -352,13 +352,15 @@ for (const { id } of toCheck) {
       // Build a universal conversation link
       const lookupId = conv?.uuid ?? conv?.id ?? id;
       const uuid = await tryResolveConversationUuid(lookupId, { inlineThread });
+
       if (!uuid) {
-        logger.warn({ convId: id }, 'skip alert: cannot resolve conversation UUID');
-        metrics.increment('alerts.skipped_producer_violation');
+        logger?.warn?.({ convId: id }, 'skip alert: cannot resolve conversation UUID');
+        metrics?.increment?.('alerts.skipped_missing_uuid');
         skipped.push(id);
         skippedCount++;
-        continue;
+        continue; // do not send without a working link
       }
+
       const url = conversationDeepLinkFromUuid(uuid);
       const idDisplay = conversationIdDisplay({ uuid, id: lookupId });
 

--- a/tests/resolve-uuid.spec.js
+++ b/tests/resolve-uuid.spec.js
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+import { tryResolveConversationUuid } from '../apps/server/lib/conversations.js';
+
+test('mines uuid from inlineThread messages (body contains deep link)', async () => {
+  const uuid = '123e4567-e89b-12d3-a456-426614174000';
+  const inlineThread = {
+    messages: [{ body: `see https://app.boomnow.com/dashboard/guest-experience/cs?conversation=${uuid}` }],
+  };
+  const got = await tryResolveConversationUuid('991130', { inlineThread });
+  expect(got).toBe(uuid);
+});
+
+test('mines uuid from structured conversation.uuid in messages', async () => {
+  const uuid = '123e4567-e89b-12d3-a456-426614174000';
+  const inlineThread = { messages: [{ conversation: { uuid } }] };
+  const got = await tryResolveConversationUuid('995536', { inlineThread });
+  expect(got).toBe(uuid);
+});


### PR DESCRIPTION
## Summary
- teach server resolver to mine conversation UUIDs from inline thread messages and DB lookups
- ensure cron defines inlineThread and only alerts when a UUID can be resolved
- add tests verifying UUID mining from deep links and structured message fields

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx playwright test tests/resolve-uuid.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68c60322f758832a959c230ecf1c9a4b