### PR TITLE
UUID resolution via public redirect probe; richer diagnostics; keep 'no UUID → no alert' policy

### DIFF
--- a/.github/workflows/boom-check.yml
+++ b/.github/workflows/boom-check.yml
@@ -15,6 +15,7 @@ jobs:
       SLA_MINUTES:     ${{ vars.SLA_MINUTES }}
       DEBUG:           ${{ vars.DEBUG }}
       DEBUG_MESSAGES:  ${{ vars.DEBUG_MESSAGES }}
+      APP_URL: https://app.boomnow.com
       SMTP_HOST:       ${{ secrets.SMTP_HOST }}
       SMTP_PORT:       ${{ secrets.SMTP_PORT }}
       SMTP_USER:       ${{ secrets.SMTP_USER }}

--- a/.github/workflows/boom-sla-check.yml
+++ b/.github/workflows/boom-sla-check.yml
@@ -22,6 +22,7 @@ jobs:
       DEBUG: ${{ vars.DEBUG }}
       DEBUG_MESSAGES: ${{ vars.DEBUG_MESSAGES }}
       DEFAULT_CONVERSATION_ID: ${{ vars.DEFAULT_CONVERSATION_ID }}
+      APP_URL: https://app.boomnow.com
 
     steps:
       - uses: actions/checkout@v4

--- a/apps/server/lib/conversations.js
+++ b/apps/server/lib/conversations.js
@@ -4,6 +4,25 @@ import { prisma } from '../../../lib/db.js';
 const UUID_RE =
   /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
 
+const appUrl = () => (process.env.APP_URL ?? 'https://app.boomnow.com').replace(/\/+$/,'');
+
+async function probeRedirectForUuid(idOrSlug) {
+  const base = appUrl();
+  const url  = `${base}/r/conversation/${encodeURIComponent(String(idOrSlug))}`;
+  // Some hosts disallow HEAD; try HEAD then GET with manual redirect.
+  const tryOnce = async (method) => {
+    const res = await fetch(url, { method, redirect: 'manual' });
+    const loc = res.headers.get('location') || '';
+    const m = /conversation=([0-9a-f-]{36})/i.exec(loc);
+    return m ? m[1].toLowerCase() : null;
+  };
+  try {
+    return (await tryOnce('HEAD')) || (await tryOnce('GET'));
+  } catch {
+    return null;
+  }
+}
+
 function firstUuid(str) {
   if (typeof str !== 'string') return null;
   const m = str.match(UUID_RE);
@@ -22,7 +41,6 @@ function* textFields(obj) {
 async function tryUuidFromInlineThread(inlineThread) {
   if (!inlineThread || typeof inlineThread !== 'object') return null;
 
-  // direct fields
   const direct =
     inlineThread.conversation_uuid ||
     inlineThread.conversationUuid ||
@@ -31,7 +49,6 @@ async function tryUuidFromInlineThread(inlineThread) {
   const directHit = firstUuid(String(direct || ''));
   if (directHit) return directHit;
 
-  // message arrays we might receive
   const msgs =
     (Array.isArray(inlineThread.messages) && inlineThread.messages) ||
     (Array.isArray(inlineThread.thread) && inlineThread.thread) ||
@@ -39,22 +56,14 @@ async function tryUuidFromInlineThread(inlineThread) {
 
   for (const m of msgs) {
     if (!m || typeof m !== 'object') continue;
-
-    // structured candidates
     const cands = [
-      m.conversation_uuid,
-      m.conversationUuid,
-      m.thread_uuid,
-      m.uuid,
-      m.conversation?.uuid,
-      m.thread?.uuid,
+      m.conversation_uuid, m.conversationUuid, m.thread_uuid, m.uuid,
+      m.conversation?.uuid, m.thread?.uuid,
     ];
     for (const c of cands) {
       const hit = firstUuid(String(c || ''));
       if (hit) return hit;
     }
-
-    // urls / bodies containing ?conversation=<uuid> or raw uuid
     for (const s of textFields(m)) {
       const q = s.match(/conversation=([0-9a-fA-F-]{36})/);
       if (q && UUID_RE.test(q[1])) return q[1].toLowerCase();
@@ -63,64 +72,62 @@ async function tryUuidFromInlineThread(inlineThread) {
     }
   }
 
-  // numeric/slug ids inside messages → map via DB
+  // map numeric/slug ids found in messages via DB
   const idSet = new Set();
   for (const m of msgs) {
-    const vals = [
-      m?.conversation?.id,
-      m?.conversation_id,
-      m?.meta?.conversation_id,
-      m?.headers?.conversation_id,
-    ].filter(v => v != null);
+    const vals = [m?.conversation?.id, m?.conversation_id, m?.meta?.conversation_id, m?.headers?.conversation_id]
+      .filter(v => v != null);
     for (const v of vals) idSet.add(String(v));
   }
   for (const v of idSet) {
     if (/^\d+$/.test(v)) {
-      const row = await prisma.conversation.findFirst({
-        where: { legacyId: Number(v) },
-        select: { uuid: true },
-      });
-      if (row?.uuid && isUuid(row.uuid)) return row.uuid.toLowerCase();
+      try {
+        const row = await prisma?.conversation?.findFirst?.({ where: { legacyId: Number(v) }, select: { uuid: true }});
+        if (row?.uuid && isUuid(row.uuid)) return row.uuid.toLowerCase();
+      } catch {}
     }
-    const bySlug = await prisma.conversation.findFirst({
-      where: { slug: v },
-      select: { uuid: true },
-    });
-    if (bySlug?.uuid && isUuid(bySlug.uuid)) return bySlug.uuid.toLowerCase();
+    try {
+      const bySlug = await prisma?.conversation?.findFirst?.({ where: { slug: v }, select: { uuid: true }});
+      if (bySlug?.uuid && isUuid(bySlug.uuid)) return bySlug.uuid.toLowerCase();
+    } catch {}
   }
-
   return null;
 }
 
 export async function tryResolveConversationUuid(idOrUuid, opts = {}) {
   const raw = String(idOrUuid ?? '').trim();
+  const attempted = [];
+
   if (!raw) return null;
 
-  // 1) already uuid
+  attempted.push('direct-uuid');
   if (isUuid(raw)) return raw.toLowerCase();
 
-  // 2) db lookups (legacy numeric / slug)
+  // DB paths
   try {
-    if (prisma?.conversation?.findFirst) {
-      const n = Number(raw);
-      if (Number.isInteger(n)) {
-        const byNum = await prisma.conversation.findFirst({
-          where: { legacyId: n },
-          select: { uuid: true },
-        });
-        if (byNum?.uuid && isUuid(byNum.uuid)) return byNum.uuid.toLowerCase();
-      }
-      const bySlug = await prisma.conversation.findFirst({
-        where: { slug: raw },
-        select: { uuid: true },
-      });
-      if (bySlug?.uuid && isUuid(bySlug.uuid)) return bySlug.uuid.toLowerCase();
+    const n = Number(raw);
+    if (Number.isInteger(n)) {
+      attempted.push('db-legacyId');
+      const byNum = await prisma?.conversation?.findFirst?.({ where: { legacyId: n }, select: { uuid: true }});
+      if (byNum?.uuid && isUuid(byNum.uuid)) return byNum.uuid.toLowerCase();
     }
-  } catch { /* ignore, fall through */ }
+    attempted.push('db-slug');
+    const bySlug = await prisma?.conversation?.findFirst?.({ where: { slug: raw }, select: { uuid: true }});
+    if (bySlug?.uuid && isUuid(bySlug.uuid)) return bySlug.uuid.toLowerCase();
+  } catch {}
 
-  // 3) mine inline thread
+  // Inline thread mining
+  attempted.push('inline-thread');
   const mined = await tryUuidFromInlineThread(opts.inlineThread);
   if (mined) return mined;
+
+  // NEW: Redirect probe (public route resolves legacy id/slug → uuid)
+  attempted.push('redirect-probe');
+  const probed = await probeRedirectForUuid(raw);
+  if (probed) return probed;
+
+  // Optional: expose attempted paths for caller logging (if desired)
+  opts.onDebug && opts.onDebug({ attempted });
 
   return null;
 }

--- a/cron.mjs
+++ b/cron.mjs
@@ -351,12 +351,16 @@ for (const { id } of toCheck) {
 
       // Build a universal conversation link
       const lookupId = conv?.uuid ?? conv?.id ?? id;
-      const uuid = await tryResolveConversationUuid(lookupId, { inlineThread });
+      const convId = id;
+      const uuid = await tryResolveConversationUuid(lookupId, {
+        inlineThread,
+        onDebug: (d) => logger?.debug?.({ convId, ...d }, 'uuid resolution attempted'),
+      });
 
       if (!uuid) {
-        logger?.warn?.({ convId: id }, 'skip alert: cannot resolve conversation UUID');
+        logger?.warn?.({ convId }, 'skip alert: cannot resolve conversation UUID');
         metrics?.increment?.('alerts.skipped_missing_uuid');
-        skipped.push(id);
+        skipped.push(convId);
         skippedCount++;
         continue; // do not send without a working link
       }

--- a/tests/resolve-uuid.redirect.spec.js
+++ b/tests/resolve-uuid.redirect.spec.js
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { tryResolveConversationUuid } from '../apps/server/lib/conversations.js';
+
+process.env.APP_URL = 'https://app.boomnow.com';
+
+// Monkeypatch global fetch for the test
+const OLD_FETCH = global.fetch;
+
+test.beforeEach(() => {
+  global.fetch = async (_url, _opts) => ({
+    headers: new Map([[
+      'location',
+      'https://app.boomnow.com/dashboard/guest-experience/cs?conversation=123e4567-e89b-12d3-a456-426614174000'
+    ]]),
+  });
+});
+
+test.afterEach(() => {
+  global.fetch = OLD_FETCH;
+});
+
+test('resolves via redirect probe from legacy numeric id', async () => {
+  const got = await tryResolveConversationUuid('991130', {});
+  expect(got).toBe('123e4567-e89b-12d3-a456-426614174000');
+});


### PR DESCRIPTION
## Summary
- add redirect probing helper to resolve conversation UUIDs from legacy ids or slugs
- log resolution attempts and try redirect-based lookup before skipping alerts
- cover redirect probe with unit test and set `APP_URL` in CI workflows

## Testing
- `APP_URL=https://app.boomnow.com npx playwright test` *(fails: missing Playwright browsers)*
- `node ./cron.mjs` *(fails: Failed to parse URL from undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68c605dc2dac832a8134c4670f5d69a5