### PR TITLE
UUID resolution via HTML-aware redirect probe + messages-probe; richer logs

### DIFF
--- a/cron.mjs
+++ b/cron.mjs
@@ -354,7 +354,12 @@ for (const { id } of toCheck) {
       const convId = id;
       const uuid = await tryResolveConversationUuid(lookupId, {
         inlineThread,
-        onDebug: (d) => logger?.debug?.({ convId, ...d }, 'uuid resolution attempted'),
+        fetchFirstMessage: async (idOrSlug) => {
+          const headers = authHeaders();
+          const r = await fetchMessagesWithRetry(idOrSlug, headers, { attempts: 1 });
+          return r.ok ? r.messages[0] : null;
+        },
+        onDebug: (d) => logger?.debug?.(d, 'uuid resolution attempted'),
       });
 
       if (!uuid) {

--- a/tests/resolve-uuid.redirect.spec.js
+++ b/tests/resolve-uuid.redirect.spec.js
@@ -1,25 +1,57 @@
 import { test, expect } from '@playwright/test';
 import { tryResolveConversationUuid } from '../apps/server/lib/conversations.js';
 
-process.env.APP_URL = 'https://app.boomnow.com';
-
-// Monkeypatch global fetch for the test
 const OLD_FETCH = global.fetch;
 
-test.beforeEach(() => {
-  global.fetch = async (_url, _opts) => ({
+test.afterEach(() => { global.fetch = OLD_FETCH; });
+
+test('redirect-probe: 302 Location header', async () => {
+  global.fetch = async (_u, _o) => ({
     headers: new Map([[
       'location',
       'https://app.boomnow.com/dashboard/guest-experience/cs?conversation=123e4567-e89b-12d3-a456-426614174000'
     ]]),
+    text: async () => '',
   });
-});
-
-test.afterEach(() => {
-  global.fetch = OLD_FETCH;
-});
-
-test('resolves via redirect probe from legacy numeric id', async () => {
   const got = await tryResolveConversationUuid('991130', {});
+  expect(got).toBe('123e4567-e89b-12d3-a456-426614174000');
+});
+
+test('redirect-probe: 200 meta-refresh body', async () => {
+  let calls = 0;
+  global.fetch = async (_u, _o) => {
+    calls++;
+    if (calls === 1) {
+      return { headers: new Map(), text: async () => '' };
+    }
+    return {
+      headers: new Map(),
+      text: async () => '<meta http-equiv="refresh" content="0; url=/dashboard/guest-experience/cs?conversation=123e4567-e89b-12d3-a456-426614174000">',
+    };
+  };
+  const got = await tryResolveConversationUuid('991130', {});
+  expect(got).toBe('123e4567-e89b-12d3-a456-426614174000');
+});
+
+test('redirect-probe: 200 location.replace body', async () => {
+  let calls = 0;
+  global.fetch = async (_u, _o) => {
+    calls++;
+    if (calls === 1) {
+      return { headers: new Map(), text: async () => '' };
+    }
+    return {
+      headers: new Map(),
+      text: async () => '<script>location.replace("https://app.boomnow.com/dashboard/guest-experience/cs?conversation=123e4567-e89b-12d3-a456-426614174000")</script>',
+    };
+  };
+  const got = await tryResolveConversationUuid('991130', {});
+  expect(got).toBe('123e4567-e89b-12d3-a456-426614174000');
+});
+
+test('messages-probe: returns conversation_uuid', async () => {
+  const got = await tryResolveConversationUuid('991130', {
+    fetchFirstMessage: async () => ({ conversation_uuid: '123e4567-e89b-12d3-a456-426614174000' })
+  });
   expect(got).toBe('123e4567-e89b-12d3-a456-426614174000');
 });


### PR DESCRIPTION
## Summary
- handle redirects that only expose the conversation UUID in HTML (meta-refresh or JS)
- try a lightweight messages probe when inline-thread mining doesn't reveal a UUID
- wire cron to use the messages probe and surface attempted resolution steps in logs

## Testing
- `npx playwright test tests/resolve-uuid.spec.js tests/resolve-uuid.redirect.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68c608d863dc832a94175664441ec7bc