### PR TITLE
feat: add universal conversation link

### DIFF
--- a/app/api/resolve/conversation/route.ts
+++ b/app/api/resolve/conversation/route.ts
@@ -1,0 +1,52 @@
+import { prisma } from '../../../../lib/db';
+import { redis } from '../../../../lib/redis';
+import { metrics } from '../../../../lib/metrics';
+
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+
+async function dbLookup(legacyId: number) {
+  const alias = await prisma.conversation_aliases.findUnique({ where: { legacy_id: legacyId } });
+  if (alias?.uuid) return alias.uuid.toLowerCase();
+  const row = await prisma.conversation.findFirst({ where: { legacyId }, select: { uuid: true } });
+  if (row?.uuid) {
+    await prisma.conversation_aliases.upsert({
+      where: { legacy_id: legacyId },
+      create: { legacy_id: legacyId, uuid: row.uuid.toLowerCase() },
+      update: { uuid: row.uuid.toLowerCase(), last_seen_at: new Date() },
+    });
+    return row.uuid.toLowerCase();
+  }
+  return null;
+}
+
+function json(body: any, init: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { 'Content-Type': 'application/json', ...(init.headers || {}) },
+  });
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const legacy = searchParams.get('legacyId');
+  if (!legacy || !/^\d+$/.test(legacy)) {
+    return json({ error: 'bad_request' }, { status: 400 });
+  }
+  const legacyId = Number(legacy);
+  const cacheKey = `conv:alias:legacy:${legacyId}`;
+  const cached = typeof redis?.get === 'function' ? await redis.get(cacheKey) : null;
+  if (cached && UUID_RE.test(String(cached))) {
+    metrics.increment('conv_alias.cache_hit');
+    return json({ uuid: String(cached).toLowerCase() }, { status: 200, headers: { 'Cache-Control': 'no-store' } });
+  }
+
+  const uuid = await dbLookup(legacyId);
+  if (uuid) {
+    metrics.increment('conv_alias.db_hit');
+    if (redis) await redis.set(cacheKey, uuid, { EX: 7 * 24 * 3600 });
+    return json({ uuid }, { status: 200, headers: { 'Cache-Control': 'no-store' } });
+  }
+
+  metrics.increment('conv_alias.not_found');
+  return json({ error: 'not_found' }, { status: 404 });
+}

--- a/app/dashboard/guest-experience/cs/page.tsx
+++ b/app/dashboard/guest-experience/cs/page.tsx
@@ -1,3 +1,39 @@
-export default function Page() {
-  return null;
+'use client'
+import { useEffect, useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+
+export default function CsPage() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const conversation = params.get('conversation');
+  const legacyId = params.get('legacyId');
+  const [uuid, setUuid] = useState<string | null>(conversation && UUID_RE.test(conversation) ? conversation.toLowerCase() : null);
+  const [resolving, setResolving] = useState(false);
+
+  useEffect(() => {
+    if (!uuid && legacyId && /^\d+$/.test(legacyId)) {
+      setResolving(true);
+      fetch(`/api/resolve/conversation?legacyId=${encodeURIComponent(legacyId)}`, { method: 'GET', credentials: 'include' })
+        .then(r => r.ok ? r.json() : Promise.reject(r))
+        .then(({ uuid: u }) => {
+          if (u && UUID_RE.test(u)) {
+            setUuid(u.toLowerCase());
+            const sp = new URLSearchParams(window.location.search);
+            sp.delete('legacyId');
+            sp.set('conversation', u.toLowerCase());
+            window.history.replaceState({}, '', `${window.location.pathname}?${sp.toString()}`);
+          }
+        })
+        .catch(() => {})
+        .finally(() => setResolving(false));
+    }
+  }, [legacyId, uuid]);
+
+  if (!uuid && (legacyId || resolving)) {
+    return <div style={{ padding: 16 }}>Opening conversation…</div>;
+  }
+
+  return <div data-uuid={uuid ?? ''}>Conversation {uuid}</div>;
 }

--- a/apps/server/lib/aliases.ts
+++ b/apps/server/lib/aliases.ts
@@ -1,0 +1,32 @@
+import { prisma } from '../../../lib/db';
+import { redis } from '../../../lib/redis';
+import { metrics } from '../../../lib/metrics';
+
+const KEY = (id: number) => `conv:alias:legacy:${id}`;
+
+export const aliases = {
+  async lookupByLegacyId(legacyId: number): Promise<string | null> {
+    const cacheKey = KEY(legacyId);
+    const cached = typeof redis?.get === 'function' ? await redis.get(cacheKey) : null;
+    if (cached) {
+      metrics.increment('conv_alias.cache_hit');
+      return String(cached);
+    }
+    const alias = await prisma.conversation_aliases.findUnique({ where: { legacy_id: legacyId } });
+    if (alias?.uuid) {
+      metrics.increment('conv_alias.db_hit');
+      if (redis) await redis.set(cacheKey, alias.uuid);
+      return alias.uuid;
+    }
+    metrics.increment('conv_alias.not_found');
+    return null;
+  },
+  async upsert({ legacyId, uuid, slug }: { legacyId: number; uuid: string; slug?: string }) {
+    await prisma.conversation_aliases.upsert({
+      where: { legacy_id: legacyId },
+      create: { legacy_id: legacyId, uuid, slug },
+      update: { uuid, slug, last_seen_at: new Date() },
+    });
+    if (redis) await redis.set(KEY(legacyId), uuid);
+  },
+};

--- a/apps/shared/lib/links.ts
+++ b/apps/shared/lib/links.ts
@@ -2,9 +2,19 @@ import { isUuid } from './uuid';
 const trim = (s: string) => s.replace(/\/+$/, '');
 export const appUrl = () => trim(process.env.APP_URL ?? 'https://app.boomnow.com');
 
-export function conversationDeepLinkFromUuid(uuid: string): string {
-  if (!uuid || !isUuid(uuid)) {
-    throw new Error('conversationDeepLinkFromUuid: valid UUID required');
+export function conversationLink({ uuid, legacyId }: { uuid?: string | null; legacyId?: number | string | null }) {
+  const base = appUrl();
+  if (uuid && isUuid(String(uuid))) {
+    return `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(String(uuid).toLowerCase())}`;
   }
-  return `${appUrl()}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(uuid.toLowerCase())}`;
+  if (legacyId != null && /^\d+$/.test(String(legacyId))) {
+    return `${base}/dashboard/guest-experience/cs?legacyId=${encodeURIComponent(String(legacyId))}`;
+  }
+  return null;
+}
+
+export function conversationDeepLinkFromUuid(uuid: string): string {
+  const link = conversationLink({ uuid });
+  if (!link) throw new Error('conversationDeepLinkFromUuid: valid UUID required');
+  return link;
 }

--- a/apps/worker/mailer/alerts.tsx
+++ b/apps/worker/mailer/alerts.tsx
@@ -1,22 +1,25 @@
-import { conversationDeepLinkFromUuid } from '../../shared/lib/links';
+import { conversationLink } from '../../shared/lib/links';
 import { verifyConversationLink } from '../../shared/lib/verifyLink';
 import { metrics } from '../../../lib/metrics';
 
 export async function buildAlertEmail(
-  event: { conversation_uuid?: string },
+  event: { conversation_uuid?: string; legacyId?: number | string },
   deps?: { logger?: any; verify?: (url: string) => Promise<boolean> }
 ) {
   const uuid = event?.conversation_uuid;
-  if (!uuid) {
-    deps?.logger?.warn({ event }, 'producer_violation');
-    metrics.increment('alerts.skipped_producer_violation');
+  const legacyId = event?.legacyId;
+  const url = conversationLink({ uuid, legacyId });
+  if (!url) {
+    deps?.logger?.warn({ event }, 'skip alert: missing conversation id');
+    metrics.increment('alerts.skipped_missing_uuid');
     return null;
   }
-  const url = conversationDeepLinkFromUuid(uuid);
   const ok = await (deps?.verify ?? verifyConversationLink)(url);
   if (!ok) {
     deps?.logger?.warn({ url }, 'link_verification_failed');
+    metrics.increment('alerts.skipped_link_preflight');
     return null;
   }
+  metrics.increment(uuid ? 'alerts.sent_with_uuid' : 'alerts.sent_with_legacyId');
   return `<p>Alert for conversation <a href="${url}">${url}</a></p>`;
 }

--- a/cron.mjs
+++ b/cron.mjs
@@ -5,7 +5,7 @@ import nodemailer from "nodemailer";
 import translate from "@vitalets/google-translate-api";
 import { isDuplicateAlert, markAlerted, dedupeKey } from "./dedupe.mjs";
 import { selectTop50, assertTop50 } from "./src/lib/selectTop50.js";
-import { conversationDeepLinkFromUuid, conversationIdDisplay } from "./lib/links.js";
+import { conversationLink, conversationIdDisplay } from "./lib/links.js";
 import { tryResolveConversationUuid } from "./apps/server/lib/conversations.js";
 import { prisma } from "./lib/db.js";
 const logger = console;
@@ -389,16 +389,26 @@ for (const { id } of toCheck) {
         }) ||
         await resolveViaInternalEndpoint(lookupId);
 
-      if (!uuid) {
-        logger?.warn?.({ convId }, 'skip alert: cannot resolve conversation UUID');
+      const url = conversationLink({ uuid, legacyId: convId });
+      if (!url) {
+        logger?.warn?.({ convId }, 'skip alert: cannot resolve conversation link');
         metrics?.increment?.('alerts.skipped_missing_uuid');
         skipped.push(convId);
         skippedCount++;
-        continue; // do not send without a working link
+        continue;
       }
-
-      const url = conversationDeepLinkFromUuid(uuid);
       const idDisplay = conversationIdDisplay({ uuid, id: lookupId });
+
+      try {
+        const pre = await fetch(url, { method: 'GET', redirect: 'manual' });
+        if (!(pre.ok || (pre.status >= 300 && pre.status < 400))) throw new Error(String(pre.status));
+      } catch {
+        logger?.warn?.({ convId, url }, 'skip alert: link did not pass preflight');
+        metrics?.increment?.('alerts.skipped_link_preflight');
+        skipped.push(convId);
+        skippedCount++;
+        continue;
+      }
 
       console.log(
         `ALERT: conv=${id} guest_unanswered=${ageMin}m > ${SLA_MIN}m -> email ${mask(to) || "(no recipient set)"} link=${url}`

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,10 +1,60 @@
+const conversations = new Map();
+const aliases = new Map();
 export const prisma = {
   conversation: {
-    async findFirst(_args) {
+    _data: conversations,
+    async findFirst(args) {
+      const where = args?.where ?? {};
+      if (where.legacyId != null) {
+        const row = conversations.get(Number(where.legacyId));
+        if (!row) return null;
+        return args?.select?.uuid ? { uuid: row.uuid } : row;
+      }
+      if (where.slug != null) {
+        for (const row of conversations.values()) {
+          if (row.slug === where.slug) {
+            return args?.select?.uuid ? { uuid: row.uuid } : row;
+          }
+        }
+      }
       return null;
     },
-    async findUnique(_args) {
+    async findUnique(args) {
+      const uuid = args?.where?.uuid;
+      if (!uuid) return null;
+      for (const row of conversations.values()) {
+        if (row.uuid === uuid) return row;
+      }
       return null;
+    },
+  },
+  conversation_aliases: {
+    _data: aliases,
+    async findUnique(args) {
+      const legacy = args?.where?.legacy_id;
+      if (legacy == null) return null;
+      return aliases.get(Number(legacy)) || null;
+    },
+    async upsert(args) {
+      const legacy = Number(args?.where?.legacy_id);
+      const existing = aliases.get(legacy);
+      if (existing) {
+        const updated = {
+          ...existing,
+          ...args.update,
+          last_seen_at: args.update?.last_seen_at ?? new Date(),
+        };
+        aliases.set(legacy, updated);
+        return updated;
+      }
+      const created = {
+        legacy_id: legacy,
+        uuid: args.create?.uuid,
+        slug: args.create?.slug,
+        last_seen_at: args.create?.last_seen_at ?? new Date(),
+      };
+      aliases.set(legacy, created);
+      return created;
     },
   },
 };

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,10 +1,62 @@
+type ConvRow = { uuid: string; legacyId?: number; slug?: string };
+const conversations = new Map<number, ConvRow>();
+const aliases = new Map<number, { legacy_id: number; uuid: string; slug?: string; last_seen_at: Date }>();
+
 export const prisma = {
   conversation: {
-    async findFirst(_args: any) {
+    _data: conversations,
+    async findFirst(args: any) {
+      const where = args?.where ?? {};
+      if (where.legacyId != null) {
+        const row = conversations.get(Number(where.legacyId));
+        if (!row) return null;
+        return args?.select?.uuid ? { uuid: row.uuid } : row;
+      }
+      if (where.slug != null) {
+        for (const row of conversations.values()) {
+          if (row.slug === where.slug) {
+            return args?.select?.uuid ? { uuid: row.uuid } : row;
+          }
+        }
+      }
       return null;
     },
-    async findUnique(_args: any) {
+    async findUnique(args: any) {
+      const uuid = args?.where?.uuid;
+      if (!uuid) return null;
+      for (const row of conversations.values()) {
+        if (row.uuid === uuid) return row;
+      }
       return null;
+    },
+  },
+  conversation_aliases: {
+    _data: aliases,
+    async findUnique(args: any) {
+      const legacy = args?.where?.legacy_id;
+      if (legacy == null) return null;
+      return aliases.get(Number(legacy)) || null;
+    },
+    async upsert(args: any) {
+      const legacy = Number(args?.where?.legacy_id);
+      const existing = aliases.get(legacy);
+      if (existing) {
+        const updated = {
+          ...existing,
+          ...args.update,
+          last_seen_at: args.update?.last_seen_at ?? new Date(),
+        };
+        aliases.set(legacy, updated);
+        return updated;
+      }
+      const created = {
+        legacy_id: legacy,
+        uuid: args.create?.uuid,
+        slug: args.create?.slug,
+        last_seen_at: args.create?.last_seen_at ?? new Date(),
+      };
+      aliases.set(legacy, created);
+      return created;
     },
   },
 };

--- a/lib/links.js
+++ b/lib/links.js
@@ -1,11 +1,20 @@
 import { isUuid } from '../apps/shared/lib/uuid.js';
 export const trim = (s) => s.replace(/\/+$/, '');
 export const appUrl = () => trim(process.env.APP_URL ?? 'https://app.boomnow.com');
-export function conversationDeepLinkFromUuid(uuid) {
-  if (!uuid || !isUuid(uuid)) {
-    throw new Error('conversationDeepLinkFromUuid: valid UUID required');
+export function conversationLink({ uuid, legacyId }) {
+  const base = appUrl();
+  if (uuid && isUuid(String(uuid))) {
+    return `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(String(uuid).toLowerCase())}`;
   }
-  return `${appUrl()}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(uuid.toLowerCase())}`;
+  if (legacyId != null && /^\d+$/.test(String(legacyId))) {
+    return `${base}/dashboard/guest-experience/cs?legacyId=${encodeURIComponent(String(legacyId))}`;
+  }
+  return null;
+}
+export function conversationDeepLinkFromUuid(uuid) {
+  const link = conversationLink({ uuid });
+  if (!link) throw new Error('conversationDeepLinkFromUuid: valid UUID required');
+  return link;
 }
 export function conversationIdDisplay(c) {
   return (c?.uuid ?? c?.id);

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -1,4 +1,4 @@
-export { appUrl, conversationDeepLinkFromUuid } from '../apps/shared/lib/links';
+export { appUrl, conversationDeepLinkFromUuid, conversationLink } from '../apps/shared/lib/links';
 
 export function conversationIdDisplay(c: { uuid?: string; id?: number | string }) {
   return (c?.uuid ?? c?.id) as string | number | undefined;

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,0 +1,9 @@
+const store = new Map<string, string>();
+export const redis = {
+  async get(key: string) {
+    return store.get(key) ?? null;
+  },
+  async set(key: string, value: string, _opts?: any) {
+    store.set(key, value);
+  },
+};

--- a/tests/deep-link.spec.ts
+++ b/tests/deep-link.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from '@playwright/test';
 
 test('deep-link to conversation loads without runtime errors', async ({ page }) => {
   const id = 'test-123';
-  await page.goto(`http://localhost:3000/dashboard/guest-experience/cs?conversation=${id}`);
+  await page.goto(`http://127.0.0.1:3000/dashboard/guest-experience/cs?conversation=${id}`);
 
   // No fatal overlay/dialog appears
   const errorDialog = page.getByText(/TypeError: undefined is not an object/);

--- a/tests/resolve-conversation.spec.ts
+++ b/tests/resolve-conversation.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import { GET } from '../app/api/resolve/conversation/route';
+import { prisma } from '../lib/db';
+
+const uuid = '123e4567-e89b-12d3-a456-426614174000';
+
+test('known alias in DB -> 200 { uuid }', async () => {
+  await prisma.conversation_aliases.upsert({
+    where: { legacy_id: 123 },
+    create: { legacy_id: 123, uuid },
+    update: { uuid },
+  });
+  const res = await GET(new Request('http://test/api/resolve/conversation?legacyId=123'));
+  expect(res.status).toBe(200);
+  const json = await res.json();
+  expect(json).toEqual({ uuid });
+});
+
+test('not found -> 404', async () => {
+  const res = await GET(new Request('http://test/api/resolve/conversation?legacyId=999999'));
+  expect(res.status).toBe(404);
+});

--- a/tests/universal-page.spec.ts
+++ b/tests/universal-page.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+import { prisma } from '../lib/db';
+
+const uuid = '123e4567-e89b-12d3-a456-426614174000';
+
+test('legacyId resolves to conversation uuid on page', async ({ page }) => {
+  await prisma.conversation_aliases.upsert({
+    where: { legacy_id: 456 },
+    create: { legacy_id: 456, uuid },
+    update: { uuid },
+  });
+  await page.goto('http://127.0.0.1:3000/dashboard/guest-experience/cs?legacyId=456');
+  await expect(page).toHaveURL(/conversation=123e4567-e89b-12d3-a456-426614174000/);
+});


### PR DESCRIPTION
## Summary
- add API endpoint to resolve legacy conversation ids to UUIDs with cache and metrics
- support universal conversation links and UUID fallback in dashboard, mailer, and cron
- introduce alias helpers and tests for link generation and resolver

## Testing
- `npx playwright test tests/conversation-link.spec.ts tests/internal-resolver.spec.ts tests/resolve-conversation.spec.ts`
- `npx playwright test tests/universal-page.spec.ts` *(fails: browserType.launch: Target page, context or browser has been closed)*
- `npx playwright test tests/deep-link.spec.ts` *(fails: browserType.launch: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_e_68c610184540832ab70064fd5df5d3fb