### PR TITLE
Use /r/legacy/:id redirect; stop sending ?legacyId= links

### DIFF
--- a/app/r/legacy/[id]/route.ts
+++ b/app/r/legacy/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server.js'
+import { prisma } from '../../../../lib/db'
+
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i
+const appUrl = () => {
+  let url = process.env.APP_URL ?? 'https://app.boomnow.com'
+  while (url.endsWith('/')) url = url.slice(0, -1)
+  return url
+}
+
+async function resolveUuid(legacyIdStr: string) {
+  const n = Number(legacyIdStr)
+  if (!Number.isInteger(n)) return null
+
+  // optional fast path if you have an alias table
+  try {
+    const alias = await prisma.conversation_aliases?.findUnique({ where: { legacy_id: n } })
+    if (alias?.uuid && UUID_RE.test(alias.uuid)) return alias.uuid.toLowerCase()
+  } catch {}
+
+  const row = await prisma.conversation.findFirst({ where: { legacyId: n }, select: { uuid: true } })
+  return row?.uuid && UUID_RE.test(row.uuid) ? row.uuid.toLowerCase() : null
+}
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+export const revalidate = 0
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const base = appUrl()
+  const uuid = await resolveUuid(params.id)
+
+  const target = uuid
+    ? `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(uuid)}`
+    : `${base}/dashboard/guest-experience/cs`
+
+  const html = `<!doctype html>
+    <meta http-equiv="refresh" content="0; url=${target}">
+    <script>try{location.replace(${JSON.stringify(target)})}catch(e){location.href=${JSON.stringify(target)}}<\/script>`
+  return new NextResponse(html, {
+    status: 302,
+    headers: { Location: target, 'content-type': 'text/html; charset=utf-8', 'cache-control': 'no-store' }
+  })
+}
+

--- a/apps/shared/lib/links.ts
+++ b/apps/shared/lib/links.ts
@@ -1,20 +1,19 @@
-import { isUuid } from './uuid';
-const trim = (s: string) => s.replace(/\/+$/, '');
-export const appUrl = () => trim(process.env.APP_URL ?? 'https://app.boomnow.com');
+const trim = (s: string) => s.replace(/\/+$/,'')
+export const appUrl = () => trim(process.env.APP_URL ?? 'https://app.boomnow.com')
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i
 
-export function conversationLink({ uuid, legacyId }: { uuid?: string | null; legacyId?: number | string | null }) {
-  const base = appUrl();
-  if (uuid && isUuid(String(uuid))) {
-    return `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(String(uuid).toLowerCase())}`;
-  }
-  if (legacyId != null && /^\d+$/.test(String(legacyId))) {
-    return `${base}/dashboard/guest-experience/cs?legacyId=${encodeURIComponent(String(legacyId))}`;
-  }
-  return null;
+export function makeConversationLink({ uuid, legacyId }:
+  { uuid?: string|null; legacyId?: number|string|null }) {
+  const base = appUrl()
+  if (uuid && UUID_RE.test(String(uuid)))
+    return `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(String(uuid).toLowerCase())}`
+  if (legacyId != null && /^\d+$/.test(String(legacyId)))
+    return `${base}/r/legacy/${encodeURIComponent(String(legacyId))}`
+  return null
 }
 
 export function conversationDeepLinkFromUuid(uuid: string): string {
-  const link = conversationLink({ uuid });
-  if (!link) throw new Error('conversationDeepLinkFromUuid: valid UUID required');
-  return link;
+  const link = makeConversationLink({ uuid })
+  if (!link) throw new Error('conversationDeepLinkFromUuid: valid UUID required')
+  return link
 }

--- a/apps/worker/mailer/alerts.tsx
+++ b/apps/worker/mailer/alerts.tsx
@@ -1,4 +1,4 @@
-import { conversationLink } from '../../shared/lib/links';
+import { makeConversationLink } from '../../shared/lib/links';
 import { verifyConversationLink } from '../../shared/lib/verifyLink';
 import { metrics } from '../../../lib/metrics';
 
@@ -8,7 +8,7 @@ export async function buildAlertEmail(
 ) {
   const uuid = event?.conversation_uuid;
   const legacyId = event?.legacyId;
-  const url = conversationLink({ uuid, legacyId });
+  const url = makeConversationLink({ uuid, legacyId });
   if (!url) {
     deps?.logger?.warn({ event }, 'skip alert: missing conversation id');
     metrics.increment('alerts.skipped_missing_uuid');

--- a/cron.mjs
+++ b/cron.mjs
@@ -5,7 +5,7 @@ import nodemailer from "nodemailer";
 import translate from "@vitalets/google-translate-api";
 import { isDuplicateAlert, markAlerted, dedupeKey } from "./dedupe.mjs";
 import { selectTop50, assertTop50 } from "./src/lib/selectTop50.js";
-import { conversationLink, conversationIdDisplay } from "./lib/links.js";
+import { makeConversationLink, conversationIdDisplay } from "./lib/links.js";
 import { tryResolveConversationUuid } from "./apps/server/lib/conversations.js";
 import { prisma } from "./lib/db.js";
 const logger = console;
@@ -389,7 +389,7 @@ for (const { id } of toCheck) {
         }) ||
         await resolveViaInternalEndpoint(lookupId);
 
-      const url = conversationLink({ uuid, legacyId: convId });
+      const url = makeConversationLink({ uuid, legacyId: convId });
       if (!url) {
         logger?.warn?.({ convId }, 'skip alert: cannot resolve conversation link');
         metrics?.increment?.('alerts.skipped_missing_uuid');

--- a/lib/links.js
+++ b/lib/links.js
@@ -1,18 +1,18 @@
-import { isUuid } from '../apps/shared/lib/uuid.js';
-export const trim = (s) => s.replace(/\/+$/, '');
+export const trim = (s) => s.replace(/\/+$/,'');
 export const appUrl = () => trim(process.env.APP_URL ?? 'https://app.boomnow.com');
-export function conversationLink({ uuid, legacyId }) {
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+export function makeConversationLink({ uuid, legacyId }) {
   const base = appUrl();
-  if (uuid && isUuid(String(uuid))) {
+  if (uuid && UUID_RE.test(String(uuid))) {
     return `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(String(uuid).toLowerCase())}`;
   }
   if (legacyId != null && /^\d+$/.test(String(legacyId))) {
-    return `${base}/dashboard/guest-experience/cs?legacyId=${encodeURIComponent(String(legacyId))}`;
+    return `${base}/r/legacy/${encodeURIComponent(String(legacyId))}`;
   }
   return null;
 }
 export function conversationDeepLinkFromUuid(uuid) {
-  const link = conversationLink({ uuid });
+  const link = makeConversationLink({ uuid });
   if (!link) throw new Error('conversationDeepLinkFromUuid: valid UUID required');
   return link;
 }

--- a/lib/links.ts
+++ b/lib/links.ts
@@ -1,4 +1,4 @@
-export { appUrl, conversationDeepLinkFromUuid, conversationLink } from '../apps/shared/lib/links';
+export { appUrl, conversationDeepLinkFromUuid, makeConversationLink } from '../apps/shared/lib/links';
 
 export function conversationIdDisplay(c: { uuid?: string; id?: number | string }) {
   return (c?.uuid ?? c?.id) as string | number | undefined;

--- a/tests/conversation-link.spec.ts
+++ b/tests/conversation-link.spec.ts
@@ -1,25 +1,25 @@
 import { test, expect } from '@playwright/test';
-import { conversationLink } from '../apps/shared/lib/links';
+import { makeConversationLink } from '../apps/shared/lib/links';
 import { buildAlertEmail } from '../apps/worker/mailer/alerts';
 import { metrics } from '../lib/metrics';
 
 const BASE = process.env.APP_URL ?? 'https://app.boomnow.com';
 const uuid = '123e4567-e89b-12d3-a456-426614174000';
 
-test('conversationLink builds ?conversation when uuid provided', () => {
-  expect(conversationLink({ uuid })).toBe(
+test('makeConversationLink builds ?conversation when uuid provided', () => {
+  expect(makeConversationLink({ uuid })).toBe(
     `${BASE}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(uuid)}`
   );
 });
 
-test('conversationLink builds ?legacyId when uuid missing', () => {
-  expect(conversationLink({ legacyId: 123 })).toBe(
-    `${BASE}/dashboard/guest-experience/cs?legacyId=123`
+test('makeConversationLink builds /r/legacy when uuid missing', () => {
+  expect(makeConversationLink({ legacyId: 123 })).toBe(
+    `${BASE}/r/legacy/123`
   );
 });
 
-test('conversationLink returns null when neither id provided', () => {
-  expect(conversationLink({})).toBeNull();
+test('makeConversationLink returns null when neither id provided', () => {
+  expect(makeConversationLink({})).toBeNull();
 });
 
 async function simulateAlert(event: any, deps: any) {
@@ -67,7 +67,7 @@ test('mailer falls back to legacyId when uuid missing', async () => {
   const emails: any[] = [];
   const metricsArr: string[] = [];
   const logger = { warn: () => {} };
-  const verify = async (url: string) => url.includes('legacyId=123');
+  const verify = async (url: string) => url.includes('/r/legacy/123');
   const orig = metrics.increment;
   metrics.increment = (n: string) => metricsArr.push(n);
   await simulateAlert({ legacyId: 123 }, {
@@ -77,6 +77,6 @@ test('mailer falls back to legacyId when uuid missing', async () => {
   });
   metrics.increment = orig;
   expect(emails.length).toBe(1);
-  expect(emails[0].html).toContain(`?legacyId=123`);
+  expect(emails[0].html).toContain(`/r/legacy/123`);
   expect(metricsArr).toContain('alerts.sent_with_legacyId');
 });

--- a/tests/legacy-redirect.spec.ts
+++ b/tests/legacy-redirect.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test'
+import { GET } from '../app/r/legacy/[id]/route'
+import { prisma } from '../lib/db'
+
+test('legacy redirect resolves to uuid deep link', async () => {
+  const uuid = '123e4567-e89b-12d3-a456-426614174000'
+  const legacyId = 1000576
+  prisma.conversation._data.set(legacyId, { uuid, legacyId })
+  const res = await GET(new Request(`http://test/r/legacy/${legacyId}`), { params: { id: String(legacyId) } })
+  expect(res.status).toBe(302)
+  expect(res.headers.get('location')).toBe(`https://app.boomnow.com/dashboard/guest-experience/cs?conversation=${uuid}`)
+})
+


### PR DESCRIPTION
## Summary
- add server route that redirects legacy conversation IDs to UUID deep link
- refactor link builder and mailer to use /r/legacy/:id instead of ?legacyId=
- update cron and tests for new redirect

## Testing
- `npx playwright test` *(fails: libatk-bridge2.0-0t64, libatspi2.0-0t64, libxcomposite1, libxdamage1, libxfixes3, libxrandr2, libgbm1, libxkbcommon0, libasound2t64)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b9087624832ab4b1cae1781e34e4