### PR TITLE
feat(sla): suppress alerts for closing guest messages

### DIFF
--- a/src/lib/isClosingStatement.js
+++ b/src/lib/isClosingStatement.js
@@ -1,0 +1,80 @@
+const KEYWORDS = [
+  "bye",
+  "goodbye",
+  "see you",
+  "see ya",
+  "cya",
+  "talk to you later",
+  "talk soon",
+  "thanks, bye",
+  "thanks bye",
+  "thank you, bye",
+  "thank you bye",
+  "that's all",
+  "no more questions",
+  "no further questions",
+  "cheers",
+  "take care",
+  "later",
+  "laterz",
+];
+
+const CLOSING_RE = /(thanks[^a-z0-9]{0,5})?(bye|goodbye|take care|cya|see\s+ya|later|cheers)[!.\s]*$/i;
+
+function messageBody(m) {
+  return (
+    m?.body ??
+    m?.body_text ??
+    m?.text ??
+    m?.message ??
+    m?.content ??
+    ""
+  ).toString();
+}
+
+let cachedTranslate;
+async function getTranslator() {
+  if (typeof globalThis.translate === "function") return globalThis.translate;
+  if (cachedTranslate !== undefined) return cachedTranslate;
+  try {
+    const mod = await import("@vitalets/google-translate-api");
+    cachedTranslate = mod.default || mod;
+  } catch {
+    cachedTranslate = null;
+  }
+  return cachedTranslate;
+}
+
+export async function isClosingStatement(message) {
+  const raw = messageBody(message).toLowerCase().trim();
+  if (!raw) return false;
+  for (const kw of KEYWORDS) {
+    if (raw.includes(kw)) return true;
+  }
+  if (CLOSING_RE.test(raw)) return true;
+
+  const translator = await getTranslator();
+  if (translator) {
+    try {
+      const res = await translator(raw, { to: "en" });
+      const translated = (res?.text || "").toLowerCase();
+      for (const kw of KEYWORDS) {
+        if (translated.includes(kw)) return true;
+      }
+      if (CLOSING_RE.test(translated)) return true;
+    } catch {
+      /* ignore translation errors */
+    }
+  }
+
+  if (process.env.USE_AI_INTENT === "1" && typeof globalThis.aiClassify === "function") {
+    try {
+      const { label, confidence } = await globalThis.aiClassify(raw) || {};
+      if (label === "closing" && Number(confidence) >= 0.8) return true;
+    } catch {
+      /* ignore AI errors */
+    }
+  }
+
+  return false;
+}

--- a/tests/sla-closing.spec.ts
+++ b/tests/sla-closing.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+
+const IMPORT_PATH = '../cron.mjs';
+
+function buildGuestMessage(text: string, minsAgo: number) {
+  return {
+    role: 'guest',
+    body: text,
+    timestamp: Date.now() - minsAgo * 60000,
+  };
+}
+
+async function loadEvaluator() {
+  // prevent cron.mjs from executing its main block
+  (globalThis as any).__CRON_TEST__ = true;
+  return await import(IMPORT_PATH);
+}
+
+test('skips SLA for closing phrases', async () => {
+  const { evaluateUnanswered } = await loadEvaluator();
+  const now = new Date();
+  const msgs = [buildGuestMessage('Thanks, bye!', 20)];
+  const res = await evaluateUnanswered(msgs, now, 5);
+  expect(res.ok).toBe(true);
+});
+
+test("skips SLA for 'That's all for now.'", async () => {
+  const { evaluateUnanswered } = await loadEvaluator();
+  const now = new Date();
+  const msgs = [buildGuestMessage("That's all for now.", 20)];
+  const res = await evaluateUnanswered(msgs, now, 5);
+  expect(res.ok).toBe(true);
+});
+
+test('non-English closing via translate', async () => {
+  (globalThis as any).translate = async () => ({ text: 'thanks bye' });
+  const { evaluateUnanswered } = await loadEvaluator();
+  const now = new Date();
+  const msgs = [buildGuestMessage('شكراً مع السلامة', 20)];
+  const res = await evaluateUnanswered(msgs, now, 5);
+  expect(res.ok).toBe(true);
+  delete (globalThis as any).translate;
+});
+
+test('continues SLA for non-closing question', async () => {
+  const { evaluateUnanswered } = await loadEvaluator();
+  const now = new Date();
+  const msgs = [buildGuestMessage('Any update?', 20)];
+  const res = await evaluateUnanswered(msgs, now, 5);
+  expect(res.ok).toBe(false);
+});
+
+test('treats "Thanks" without goodbye as non-closing', async () => {
+  const { evaluateUnanswered } = await loadEvaluator();
+  const now = new Date();
+  const msgs = [buildGuestMessage('Thanks', 20)];
+  const res = await evaluateUnanswered(msgs, now, 5);
+  expect(res.ok).toBe(false);
+});
+
+test('AI fallback honors confidence', async () => {
+  const { isClosingStatement } = await import('../src/lib/isClosingStatement.js');
+  process.env.USE_AI_INTENT = '1';
+  (globalThis as any).aiClassify = async () => ({ label: 'closing', confidence: 0.85 });
+  await expect(isClosingStatement({ body: 'random words' })).resolves.toBe(true);
+  (globalThis as any).aiClassify = async () => ({ label: 'closing', confidence: 0.6 });
+  await expect(isClosingStatement({ body: 'random words' })).resolves.toBe(false);
+  delete (globalThis as any).aiClassify;
+  delete process.env.USE_AI_INTENT;
+});


### PR DESCRIPTION
## Summary
- add closing-intent helper with keyword, regex, translation, and AI intent support
- ignore untranslated closing messages during SLA evaluation
- test closing detection across languages and AI fallback

## Testing
- `npx playwright test` *(fails: net::ERR_CERT_AUTHORITY_INVALID, net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cff2362c832a8607b97048e79152