### PR TITLE
Handle legacy fallback for CS redirect

### DIFF
--- a/app/r/legacy/[id]/route.ts
+++ b/app/r/legacy/[id]/route.ts
@@ -30,9 +30,10 @@ export async function GET(_req: Request, { params }: { params: { id: string } })
   const base = appUrl()
   const uuid = await resolveUuid(params.id)
 
+  // If we couldn't resolve a UUID on the server, pass legacyId so the CS page can resolve it.
   const target = uuid
     ? `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(uuid)}`
-    : `${base}/dashboard/guest-experience/cs`
+    : `${base}/dashboard/guest-experience/cs?legacyId=${encodeURIComponent(params.id)}`
 
   const html = `<!doctype html>
     <meta http-equiv="refresh" content="0; url=${target}">


### PR DESCRIPTION
## Summary
- forward legacy conversation id when UUID resolution fails to allow client-side lookup

## Testing
- `npx playwright test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c71942b6f0832a95268c0ee7e4cd44