### PR TITLE
Handle non-UUID conversation links in cron alerts

### DIFF
--- a/.github/workflows/boom-cron.yml
+++ b/.github/workflows/boom-cron.yml
@@ -40,6 +40,7 @@ jobs:
       TOTAL_CONVERSATIONS_ESTIMATE: ${{ vars.TOTAL_CONVERSATIONS_ESTIMATE }}
       MAX_CONCURRENCY:            ${{ vars.MAX_CONCURRENCY }}
       APP_URL: https://app.boomnow.com
+      RESOLVE_SECRET: ${{ secrets.RESOLVE_SECRET }}
       LIST_SORT_FIELD:            ${{ vars.LIST_SORT_FIELD }}
       LIST_SORT_ORDER_RECENT:     ${{ vars.LIST_SORT_ORDER_RECENT }}
       LIST_SORT_ORDER_BACKFILL:   ${{ vars.LIST_SORT_ORDER_BACKFILL }}


### PR DESCRIPTION
## Summary
- fallback to `?legacyId=` or redirect when UUID lookup fails to keep alert links functional
- auto-resolve numeric `conversation` query params on CS page
- expose `RESOLVE_SECRET` to cron workflow to enable internal resolver

## Testing
- `npx playwright test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b0d31fcc832ab1e348dd7b3db8e6