### PR TITLE
Preserve conversation identifiers in redirect paths

### DIFF
--- a/app/r/conversation/[id]/route.ts
+++ b/app/r/conversation/[id]/route.ts
@@ -7,9 +7,15 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
-  const uuid = await tryResolveConversationUuid(params.id);
+  const raw = params.id;
+  const uuid = await tryResolveConversationUuid(raw);
+  const base = appUrl();
   const to = uuid
     ? conversationDeepLinkFromUuid(uuid)
-    : `${appUrl()}/dashboard/guest-experience/cs`;
+    : (/^\d+$/.test(raw)
+        // Numeric legacy id → let the server resolver map to UUID
+        ? `${base}/r/legacy/${encodeURIComponent(raw)}`
+        // Non‑numeric slug → open CS with the slug preserved
+        : `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(raw)}`);
   return NextResponse.redirect(to, 302);
 }

--- a/cron.mjs
+++ b/cron.mjs
@@ -388,16 +388,15 @@ for (const { id } of toCheck) {
 
       // Build a working link:
       //  - If we have a UUID, use the canonical deep link (?conversation=<uuid>)
-      //  - If we *don't* have a UUID:
-      //      * numeric id → use ?legacyId=<id> (CS page will resolve → UUID and update URL)
-      //      * non-numeric slug → use the short redirect (/r/conversation/<id>)
+      //  - If we *don't* have a UUID, use a resolver link:
+      //      * numeric id → /r/legacy/<id>
+      //      * non-numeric slug → /r/conversation/<slug>
       const base = (process.env.APP_URL || 'https://app.boomnow.com').replace(/\/+$/,'');
-      const isNumericId = /^\d+$/.test(String(lookupId));
-      const url =
-        makeConversationLink({ uuid }) ||
-        (isNumericId
-          ? `${base}/dashboard/guest-experience/cs?legacyId=${encodeURIComponent(String(lookupId))}`
-          : `${base}/r/conversation/${encodeURIComponent(String(lookupId))}`);
+      const lookup = String(lookupId);
+      const fallbackUrl = /^\d+$/.test(lookup)
+        ? `${base}/r/legacy/${encodeURIComponent(lookup)}`
+        : `${base}/r/conversation/${encodeURIComponent(lookup)}`;
+      const url = makeConversationLink({ uuid }) || fallbackUrl;
       const idDisplay = conversationIdDisplay({ uuid, id: lookupId });
 
       try {


### PR DESCRIPTION
## Summary
- Preserve the raw conversation id in `/r/conversation/:id` redirects, forwarding numeric ids to `/r/legacy/:id` and slugs via the CS page
- Update cron/mailer fallback links to use the resolver endpoints when no UUID is available

## Testing
- `npx playwright test`
- `npx playwright test tests/universal-page.spec.ts` *(fails: Host system missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cdc67154832a86e3eeb41a82422b