### PR TITLE
Fix CS deep link for numeric ids; harden related_reservations; preserve id on shortlink fallback; wire resolver secret

### DIFF
--- a/app/dashboard/guest-experience/cs/page.tsx
+++ b/app/dashboard/guest-experience/cs/page.tsx
@@ -55,7 +55,7 @@ export default function CsPage() {
     return <div style={{ padding: 16 }}>Conversation not found or has been deleted.</div>;
   }
 
-  if (!uuid && (legacyId || resolving)) {
+  if (!uuid && (legacyId || numericConversation || resolving)) {
     return <div style={{ padding: 16 }}>Opening conversation…</div>;
   }
 


### PR DESCRIPTION
## Summary
- Auto-resolve numeric conversation IDs to UUIDs and rewrite URL on CS page
- Harden related_reservations handling to always use safe defaults
- Provide safe defaults from API and shortlink fallbacks preserving IDs
- Wire RESOLVE_SECRET into cron workflow

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c824b67cb4832a8241763484c124d4