### PR TITLE
CS deep-link: resolve numeric ids; preserve shortlink ids; UI safety; cron resolver secret; add tests script

### DIFF
--- a/app/c/[id]/route.ts
+++ b/app/c/[id]/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server.js';
 import { prisma } from '../../../lib/db';
 import { conversationDeepLinkFromUuid, appUrl } from '../../../apps/shared/lib/links';
-import { tryResolveConversationUuid } from '../../../apps/server/lib/conversations';
+// Use robust JS resolver (supports legacyId/slug/redirect probe)
+import { tryResolveConversationUuid } from '../../../apps/server/lib/conversations.js';
 
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
   const raw = params.id;

--- a/app/r/conversation/[id]/route.ts
+++ b/app/r/conversation/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server.js';
-import { tryResolveConversationUuid } from '../../../../apps/server/lib/conversations';
+// Use robust JS resolver (supports legacyId/slug/redirect probe)
+import { tryResolveConversationUuid } from '../../../../apps/server/lib/conversations.js';
 import { conversationDeepLinkFromUuid, appUrl } from '../../../../apps/shared/lib/links';
 
 export const runtime = 'nodejs';

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.45.0"
+  },
+  "scripts": {
+    "test": "playwright test --reporter=list"
   }
 }


### PR DESCRIPTION
## Summary
- handle numeric conversation IDs and legacy IDs in CS deep links
- use JS resolver in redirect routes and expose resolve secret to cron job
- add Playwright test runner script

## Testing
- `npm test` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c83177e8a0832aae1afb79cc0d8ae5