### PR TITLE
Improve legacy redirect to resolve UUIDs

### DIFF
--- a/app/r/legacy/[id]/route.ts
+++ b/app/r/legacy/[id]/route.ts
@@ -1,12 +1,43 @@
 import { NextResponse } from 'next/server.js';
-import { appUrl } from '../../../../apps/shared/lib/links';
+import { prisma } from '../../../../lib/db';
+import { appUrl, makeConversationLink } from '../../../../apps/shared/lib/links';
+import { isUuid } from '../../../../apps/shared/lib/uuid';
+
+async function resolveUuid(legacyIdStr: string) {
+  const n = Number(legacyIdStr);
+  if (!Number.isInteger(n)) return null;
+
+  try {
+    const alias = await prisma.conversation_aliases?.findUnique?.({ where: { legacy_id: n } });
+    if (alias?.uuid && isUuid(alias.uuid)) return alias.uuid.toLowerCase();
+  } catch {}
+
+  const row = await prisma.conversation.findFirst({ where: { legacyId: n }, select: { uuid: true } });
+  return row?.uuid && isUuid(row.uuid) ? row.uuid.toLowerCase() : null;
+}
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
-  // Always land on the CS page; the app/page handles UUID vs numeric.
-  const to = `${appUrl()}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(params.id)}`;
-  return NextResponse.redirect(to, 302);
+  const base = appUrl();
+  const uuid = await resolveUuid(params.id);
+
+  const target = uuid
+    ? makeConversationLink({ uuid }) ?? `${base}/conversation-not-found`
+    : `${base}/conversation-not-found`;
+
+  const html = `<!doctype html>
+    <meta http-equiv="refresh" content="0; url=${target}">
+    <script>try{location.replace(${JSON.stringify(target)})}catch(e){location.href=${JSON.stringify(target)}}<\/script>`;
+
+  return new NextResponse(html, {
+    status: 302,
+    headers: {
+      Location: target,
+      'content-type': 'text/html; charset=utf-8',
+      'cache-control': 'no-store',
+    },
+  });
 }


### PR DESCRIPTION
## Summary
- resolve legacy conversation ids to UUIDs using aliases or conversations before redirecting
- return conversation-not-found redirect with HTML fallback for in-app browsers when unresolved

## Testing
- npx playwright test tests/legacy-redirect.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68c85f4b72c4832aa6f6ec7ef069a180