### PR TITLE
Update conversation redirect fallback

### DIFF
--- a/app/r/conversation/[id]/route.ts
+++ b/app/r/conversation/[id]/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server.js';
-// Use robust JS resolver (supports legacyId/slug/redirect probe)
-import { tryResolveConversationUuid } from '../../../../apps/server/lib/conversations.js';
+import { tryResolveConversationUuid } from '../../../../apps/server/lib/conversations';
 import { conversationDeepLinkFromUuid, appUrl } from '../../../../apps/shared/lib/links';
 
 export const runtime = 'nodejs';
@@ -8,10 +7,9 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
-  const raw = params.id;
-  const uuid = await tryResolveConversationUuid(raw);
+  const uuid = await tryResolveConversationUuid(params.id);
   const to = uuid
     ? conversationDeepLinkFromUuid(uuid)
-    : `${appUrl()}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(raw)}`;
+    : `${appUrl()}/dashboard/guest-experience/cs`;
   return NextResponse.redirect(to, 302);
 }


### PR DESCRIPTION
## Summary
- simplify the conversation redirect route to rely on the shared resolver directly
- update the fallback redirect target to the guest experience dashboard when the UUID cannot be resolved

## Testing
- npm test *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c860cfbfdc832ab83ccd0d51a5e9e9