### PR TITLE
Chunk 3: CS resolves numeric conversation ids

### DIFF
--- a/app/dashboard/guest-experience/cs/page.tsx
+++ b/app/dashboard/guest-experience/cs/page.tsx
@@ -39,7 +39,7 @@ export default function CsPage() {
             setUuid(u.toLowerCase());
             const sp = new URLSearchParams(window.location.search);
             sp.delete('legacyId');
-            if (numericConversation) sp.delete('conversation'); // prevent loops
+            if (numericConversation) sp.delete('conversation');
             sp.set('conversation', u.toLowerCase());
             window.history.replaceState({}, '', `${window.location.pathname}?${sp.toString()}`);
           } else if (!data) {


### PR DESCRIPTION
## Summary
- allow numeric `conversation` query parameters to be treated as legacy identifiers and resolved to UUIDs
- replace the query string with the resolved UUID while dropping legacy and numeric placeholders to avoid loops

## Testing
- npm test *(fails: Playwright browsers not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68c867f10e2c832a99eff5eb5c3b0c3b