### PR TITLE
Add robust conversation resolve APIs

### DIFF
--- a/app/api/internal/resolve-conversation/route.test.ts
+++ b/app/api/internal/resolve-conversation/route.test.ts
@@ -3,55 +3,107 @@ import { signResolve } from '../../../../apps/shared/lib/resolveSign.js';
 import { prisma } from '../../../../lib/db.js';
 
 const uuid = '123e4567-e89b-12d3-a456-426614174000';
+const originalFindFirst = prisma.conversation.findFirst;
+const originalFindUnique = prisma.conversation.findUnique;
+const conversations = prisma.conversation._data as Map<number, any>;
+const aliases = prisma.conversation_aliases._data as Map<number, any>;
+
+test.beforeEach(() => {
+  process.env.RESOLVE_SECRET = 'secret';
+  conversations.clear();
+  aliases.clear();
+  prisma.conversation.findFirst = originalFindFirst;
+  prisma.conversation.findUnique = originalFindUnique;
+});
+
+test.afterEach(() => {
+  delete process.env.RESOLVE_SECRET;
+});
 
 function makeUrl(id: string, ts: number, nonce: string, sig: string) {
   return `https://example.com/api/internal/resolve-conversation?id=${id}&ts=${ts}&nonce=${nonce}&sig=${sig}`;
 }
 
 test('valid signature + known legacyId -> 200 { uuid }', async () => {
-  process.env.RESOLVE_SECRET = 'secret';
   const { GET } = await import('./route');
   const ts = Date.now();
   const nonce = 'abc';
   const id = '123';
-  const sig = signResolve(id, ts, nonce, 'secret');
-  prisma.conversation.findFirst = async () => ({ uuid });
+  const sig = signResolve(id, ts, nonce, process.env.RESOLVE_SECRET!);
+  conversations.set(123, { uuid, legacyId: 123 });
   const res = await GET(new Request(makeUrl(id, ts, nonce, sig)));
   expect(res.status).toBe(200);
   await expect(res.json()).resolves.toEqual({ uuid });
 });
 
 test('invalid signature -> 401', async () => {
-  process.env.RESOLVE_SECRET = 'secret';
   const { GET } = await import('./route');
   const ts = Date.now();
   const nonce = 'abc';
   const id = '123';
-  const valid = signResolve(id, ts, nonce, 'secret');
+  const valid = signResolve(id, ts, nonce, process.env.RESOLVE_SECRET!);
   const sig = valid.replace(/.$/, valid[valid.length - 1] === '0' ? '1' : '0');
   const res = await GET(new Request(makeUrl(id, ts, nonce, sig)));
   expect(res.status).toBe(401);
 });
 
 test('stale ts -> 400', async () => {
-  process.env.RESOLVE_SECRET = 'secret';
   const { GET } = await import('./route');
   const ts = Date.now() - 5 * 60 * 1000;
   const nonce = 'abc';
   const id = '123';
-  const sig = signResolve(id, ts, nonce, 'secret');
+  const sig = signResolve(id, ts, nonce, process.env.RESOLVE_SECRET!);
   const res = await GET(new Request(makeUrl(id, ts, nonce, sig)));
   expect(res.status).toBe(400);
 });
 
 test('not found -> 404', async () => {
-  process.env.RESOLVE_SECRET = 'secret';
   const { GET } = await import('./route');
   const ts = Date.now();
   const nonce = 'abc';
   const id = '123';
-  const sig = signResolve(id, ts, nonce, 'secret');
-  prisma.conversation.findFirst = async () => null;
+  const sig = signResolve(id, ts, nonce, process.env.RESOLVE_SECRET!);
   const res = await GET(new Request(makeUrl(id, ts, nonce, sig)));
   expect(res.status).toBe(404);
+});
+
+test('resolves via alias when legacy conversation missing', async () => {
+  const { GET } = await import('./route');
+  const ts = Date.now();
+  const nonce = 'def';
+  const id = '555';
+  await prisma.conversation_aliases.upsert({
+    where: { legacy_id: 555 },
+    create: { legacy_id: 555, uuid },
+    update: { uuid },
+  });
+  const sig = signResolve(id, ts, nonce, process.env.RESOLVE_SECRET!);
+  const res = await GET(new Request(makeUrl(id, ts, nonce, sig)));
+  expect(res.status).toBe(200);
+  await expect(res.json()).resolves.toEqual({ uuid });
+});
+
+test('resolves slug and caches alias', async () => {
+  const { GET } = await import('./route');
+  const ts = Date.now();
+  const nonce = 'ghi';
+  const slug = 'chat-99';
+  conversations.set(99, { uuid, legacyId: 99, slug });
+  const sig = signResolve(slug, ts, nonce, process.env.RESOLVE_SECRET!);
+  const res = await GET(new Request(makeUrl(slug, ts, nonce, sig)));
+  expect(res.status).toBe(200);
+  await expect(res.json()).resolves.toEqual({ uuid });
+  const alias = await prisma.conversation_aliases.findUnique({ where: { legacy_id: 99 } });
+  expect(alias).toMatchObject({ uuid, slug });
+});
+
+test('resolves uuid directly when conversation exists', async () => {
+  const { GET } = await import('./route');
+  const ts = Date.now();
+  const nonce = 'jkl';
+  conversations.set(77, { uuid, legacyId: 77 });
+  const sig = signResolve(uuid, ts, nonce, process.env.RESOLVE_SECRET!);
+  const res = await GET(new Request(makeUrl(uuid, ts, nonce, sig)));
+  expect(res.status).toBe(200);
+  await expect(res.json()).resolves.toEqual({ uuid });
 });


### PR DESCRIPTION
## Summary
- Harden the public conversation resolver by validating the legacyId input and updating alias records with slug data when falling back to the database
- Expand the signed internal resolver to handle UUID, legacy ID, and slug lookups while caching aliases and tightening signature verification
- Add unit tests covering the new resolver paths and behaviours for both public and internal endpoints

## Testing
- npm test *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c869e7a398832a9ea80d931ec33abb