### PR TITLE
Avoid redirect recursion when resolving conversations

### DIFF
--- a/app/r/conversation/[id]/route.ts
+++ b/app/r/conversation/[id]/route.ts
@@ -9,7 +9,7 @@ export const revalidate = 0;
 
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
   const raw = params.id;
-  const uuid = await tryResolveConversationUuid(raw);
+  const uuid = await tryResolveConversationUuid(raw, { skipRedirectProbe: true });
   const to = uuid
     ? conversationDeepLinkFromUuid(uuid)
     : `${appUrl()}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(raw)}`;

--- a/apps/server/lib/conversations.js
+++ b/apps/server/lib/conversations.js
@@ -162,9 +162,11 @@ export async function tryResolveConversationUuid(idOrUuid, opts = {}) {
   }
 
   // NEW: Redirect probe (public route resolves legacy id/slug → uuid)
-  attempted.push('redirect-probe');
-  const probed = await probeRedirectForUuid(raw);
-  if (probed) return probed;
+  if (!opts.skipRedirectProbe) {
+    attempted.push('redirect-probe');
+    const probed = await probeRedirectForUuid(raw);
+    if (probed) return probed;
+  }
 
   // Optional: expose attempted paths for caller logging (if desired)
   opts.onDebug && opts.onDebug({ convId: raw, attempted });


### PR DESCRIPTION
## Summary
- allow `tryResolveConversationUuid` callers to skip the redirect probe
- avoid the public redirect route recursively invoking itself by disabling the probe for that path

## Testing
- npm test *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c883021148832aaf41f28fb4d812bf