### PR TITLE
Handle direct conversation link responses with status 200

### DIFF
--- a/apps/shared/lib/verifyLink.ts
+++ b/apps/shared/lib/verifyLink.ts
@@ -1,6 +1,10 @@
 export async function verifyConversationLink(url: string): Promise<boolean> {
   try {
     const res = await fetch(url, { method: 'GET', redirect: 'manual' });
+    if (res.status === 200) {
+      // Direct deep link rendered (SPA shell)
+      return true;
+    }
     if (res.status !== 302) return false;
     const loc = res.headers.get('location') ?? '';
     if (loc.includes('/login') || loc.includes('/dashboard/guest-experience/cs')) {


### PR DESCRIPTION
## Summary
- allow `verifyConversationLink` to accept 200 responses for direct deep link rendering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c88616d628832a94dc4d205ac6931b