### PR TITLE
Add LINK_SECRET to workflow environments

### DIFF
--- a/.github/workflows/boom-check.yml
+++ b/.github/workflows/boom-check.yml
@@ -22,6 +22,7 @@ jobs:
       SMTP_PASS:       ${{ secrets.SMTP_PASS }}
       ALERT_TO:        ${{ secrets.ALERT_TO }}
       ALERT_FROM_NAME: ${{ secrets.ALERT_FROM_NAME }}
+      LINK_SECRET:     ${{ secrets.LINK_SECRET }}
       BOOM_USER:       ${{ secrets.BOOM_USER }}
       BOOM_PASS:       ${{ secrets.BOOM_PASS }}
     steps:

--- a/.github/workflows/boom-cron.yml
+++ b/.github/workflows/boom-cron.yml
@@ -57,6 +57,7 @@ jobs:
       SMTP_PASS:   ${{ secrets.SMTP_PASS }}
       ALERT_TO:    ${{ secrets.ALERT_TO }}
       ALERT_FROM_NAME: ${{ secrets.ALERT_FROM_NAME }}
+      LINK_SECRET:     ${{ secrets.LINK_SECRET }}
       # Auth for the conversations endpoint (either may be empty)
       BOOM_BEARER: ${{ secrets.BOOM_BEARER }}
       BOOM_COOKIE: ${{ secrets.BOOM_COOKIE }}

--- a/.github/workflows/boom-sla-check.yml
+++ b/.github/workflows/boom-sla-check.yml
@@ -23,6 +23,7 @@ jobs:
       DEBUG_MESSAGES: ${{ vars.DEBUG_MESSAGES }}
       DEFAULT_CONVERSATION_ID: ${{ vars.DEFAULT_CONVERSATION_ID }}
       APP_URL: https://app.boomnow.com
+      LINK_SECRET: ${{ secrets.LINK_SECRET }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- expose the LINK_SECRET secret to the cron workflow job
- add LINK_SECRET to the debug workflow environment
- surface LINK_SECRET for the manual workflow run

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c88c86ea94832aa7f24f4645147c4a