### PR TITLE
Sanitize auth headers in debug curls

### DIFF
--- a/.github/workflows/boom-check.yml
+++ b/.github/workflows/boom-check.yml
@@ -51,23 +51,22 @@ jobs:
           echo "CONVERSATIONS_URL=${CONVERSATIONS_URL}"
           echo "MESSAGES_URL=${MESSAGES_URL}"
           echo "--- RESPONSE STATUS + HEADERS ---"
-
-          # Build a single header string safely (no embedded quotes),
-          # and disable curl's URL globbing to avoid {} / [] issues.
+          # Ignore any pre-set AUTH_HEADER; it causes arg-splitting
+          unset AUTH_HEADER || true
+          # Build a single header from secrets; strip newlines
           HEADER=""
           if [[ -n "${BOOM_BEARER:-}" ]]; then
-            HEADER="Authorization: Bearer ${BOOM_BEARER}"
+            BB=$(printf '%s' "${BOOM_BEARER}" | tr -d '\r\n')
+            HEADER="Authorization: Bearer ${BB}"
           elif [[ -n "${BOOM_COOKIE:-}" ]]; then
-            HEADER="Cookie: ${BOOM_COOKIE}"
+            CK=$(printf '%s' "${BOOM_COOKIE}" | tr -d '\r\n')
+            HEADER="Cookie: ${CK}"
           fi
-
           if [[ -n "$HEADER" ]]; then
             curl --globoff -sS -D - -o /dev/null -H "$HEADER" "$CONVERSATIONS_URL"
           else
             curl --globoff -sS -D - -o /dev/null "$CONVERSATIONS_URL"
           fi
-
-          # Optional: also sanity-check the messages endpoint
           if [[ -n "${MESSAGES_URL:-}" ]]; then
             echo
             if [[ -n "$HEADER" ]]; then

--- a/.github/workflows/boom-cron.yml
+++ b/.github/workflows/boom-cron.yml
@@ -95,21 +95,34 @@ jobs:
           echo "MESSAGES_URL=${NEW_VAL}" >> "$GITHUB_ENV"
       # Sanity-check the endpoint actually returns JSON with our auth
       - name: Debug conversations endpoint (with auth)
+        shell: bash
         run: |
           set -euo pipefail
-          echo "CONVERSATIONS_URL=$CONVERSATIONS_URL"
-          echo "MESSAGES_URL=$MESSAGES_URL"
+          echo "CONVERSATIONS_URL=${CONVERSATIONS_URL}"
+          echo "MESSAGES_URL=${MESSAGES_URL}"
           echo "--- RESPONSE STATUS + HEADERS ---"
-          # --globoff prevents {} / [] URL globbing errors if someone leaves placeholders in MESSAGES_URL
-          curl --globoff -sS -D - \
-            -H "Accept: application/json" \
-            ${BOOM_BEARER:+-H "Authorization: Bearer $BOOM_BEARER"} \
-            ${BOOM_COOKIE:+-H "Cookie: $BOOM_COOKIE"} \
-            "$CONVERSATIONS_URL" \
-            -o /tmp/body.json | head -n 40
-          echo
-          echo "--- FIRST 400 BYTES OF BODY ---"
-          head -c 400 /tmp/body.json || true; echo
+          unset AUTH_HEADER || true
+          HEADER=""
+          if [[ -n "${BOOM_BEARER:-}" ]]; then
+            BB=$(printf '%s' "${BOOM_BEARER}" | tr -d '\r\n')
+            HEADER="Authorization: Bearer ${BB}"
+          elif [[ -n "${BOOM_COOKIE:-}" ]]; then
+            CK=$(printf '%s' "${BOOM_COOKIE}" | tr -d '\r\n')
+            HEADER="Cookie: ${CK}"
+          fi
+          if [[ -n "$HEADER" ]]; then
+            curl --globoff -sS -D - -o /dev/null -H "$HEADER" "$CONVERSATIONS_URL"
+          else
+            curl --globoff -sS -D - -o /dev/null "$CONVERSATIONS_URL"
+          fi
+          if [[ -n "${MESSAGES_URL:-}" ]]; then
+            echo
+            if [[ -n "$HEADER" ]]; then
+              curl --globoff -sS -D - -o /dev/null -H "$HEADER" "$MESSAGES_URL"
+            else
+              curl --globoff -sS -D - -o /dev/null "$MESSAGES_URL"
+            fi
+          fi
 
       - name: Run SLA checker
         working-directory: .

--- a/.github/workflows/boom-sla-check.yml
+++ b/.github/workflows/boom-sla-check.yml
@@ -42,7 +42,7 @@ jobs:
             npm install --no-fund --no-audit
           fi
 
-      - name: Debug conversations endpoint
+      - name: Debug conversations endpoint (with auth)
         continue-on-error: true
         shell: bash
         env:
@@ -63,19 +63,36 @@ jobs:
           fi
           echo "Hitting (sanitized): $url"
           hdrs=(-H 'Accept: application/json' -H 'User-Agent: curl/7' -H 'Referer: https://app.boomnow.com/' -H 'X-Requested-With: XMLHttpRequest')
+          # Ignore any pre-set AUTH_HEADER; it causes arg-splitting in curl
+          unset AUTH_HEADER || true
+          HEADER=""
           if [[ -n "${BOOM_BEARER:-}" ]]; then
             echo "Using Bearer auth"
-            hdrs+=(-H "Authorization: Bearer ${BOOM_BEARER}")
+            BB=$(printf '%s' "${BOOM_BEARER}" | tr -d '\r\n')
+            HEADER="Authorization: Bearer ${BB}"
           elif [[ -n "${BOOM_COOKIE:-}" ]]; then
             echo "Using Cookie auth"
-            hdrs+=(-H "Cookie: ${BOOM_COOKIE}")
+            CK=$(printf '%s' "${BOOM_COOKIE}" | tr -d '\r\n')
+            HEADER="Cookie: ${CK}"
           else
             echo "No auth provided; expect 401"
+          fi
+          if [[ -n "$HEADER" ]]; then
+            hdrs+=(-H "$HEADER")
           fi
           # never fail the job here, even on 401
           code=$(curl -sS --globoff -o /tmp/resp.json -w '%{http_code}' "${hdrs[@]}" "$url" || true) || true
           echo "HTTP $code"
           head -c 400 /tmp/resp.json || true
+          if [[ -n "${MESSAGES_URL:-}" ]]; then
+            echo
+            echo "Probing messages endpoint headers"
+            if [[ -n "$HEADER" ]]; then
+              curl --globoff -sS -D - -o /dev/null -H "$HEADER" "$MESSAGES_URL"
+            else
+              curl --globoff -sS -D - -o /dev/null "$MESSAGES_URL"
+            fi
+          fi
 
       - name: Build conversation id & messages URL
         shell: bash


### PR DESCRIPTION
## Summary
- sanitize the debug curl headers in the manual check workflow by rebuilding them from secrets and stripping newlines
- update the cron workflow probe to reuse the sanitized header for both conversations and messages endpoints
- harden the debug workflow probe to ignore inherited AUTH_HEADER values and reuse the cleaned header when calling both endpoints

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c8992f7a40832a89c03805dd50b573