### PR TITLE
Handle trailing quotes in conversation URL parsing

### DIFF
--- a/check.mjs
+++ b/check.mjs
@@ -223,10 +223,12 @@ function unwrapUrl(urlStr) {
 }
 
 function firstUrlLike(s) {
-  const m = String(s||"").match(/https?:\/\/\S+/);
+  const m = String(s || "").match(/https?:\/\/[^\s<>"]+/);
   if (!m) return "";
-  // strip trailing punctuation that often rides along in emails
-  return m[0].replace(/[>),.;!]+$/, "");
+  // strip trailing punctuation that often rides along in emails. Include quotes
+  // because URLs embedded in HTML attributes frequently end with either '"'
+  // or "'" before the closing tag, which would otherwise produce invalid URLs.
+  return m[0].replace(/[>),.;!'"`]+$/, "");
 }
 
 function extractConversationId(input) {


### PR DESCRIPTION
## Summary
- adjust the conversation URL matcher to ignore HTML attribute quotes when scraping text
- strip trailing quotes and similar punctuation so we don't feed invalid URLs into URL()

## Testing
- npm test *(fails: missing Playwright browsers in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68c956e7626c832aaec0ad003eef8d48