### PR TITLE
Reuse conversation resolver for legacy redirect

### DIFF
--- a/app/r/legacy/[id]/route.ts
+++ b/app/r/legacy/[id]/route.ts
@@ -1,20 +1,6 @@
 import { NextResponse } from 'next/server.js';
-import { prisma } from '../../../../lib/db';
-import { appUrl } from '../../../../apps/shared/lib/links';
-import { isUuid } from '../../../../apps/shared/lib/uuid';
-
-async function resolveUuid(legacyIdStr: string) {
-  const n = Number(legacyIdStr);
-  if (!Number.isInteger(n)) return null;
-
-  try {
-    const alias = await prisma.conversation_aliases?.findUnique?.({ where: { legacy_id: n } });
-    if (alias?.uuid && isUuid(alias.uuid)) return alias.uuid.toLowerCase();
-  } catch {}
-
-  const row = await prisma.conversation.findFirst({ where: { legacyId: n }, select: { uuid: true } });
-  return row?.uuid && isUuid(row.uuid) ? row.uuid.toLowerCase() : null;
-}
+import { tryResolveConversationUuid } from '../../../../apps/server/lib/conversations.js';
+import { conversationDeepLinkFromUuid, appUrl } from '../../../../apps/shared/lib/links';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -22,22 +8,13 @@ export const revalidate = 0;
 
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
   const base = appUrl();
-  const uuid = await resolveUuid(params.id);
+  let uuid: string | null = null;
+  try {
+    uuid = await tryResolveConversationUuid(params.id, { skipRedirectProbe: true });
+  } catch {
+    uuid = null;
+  }
 
-  const target = uuid
-    ? `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(uuid)}`
-    : `${base}/conversation-not-found`;
-
-  const html = `<!doctype html>
-    <meta http-equiv="refresh" content="0; url=${target}">
-    <script>try{location.replace(${JSON.stringify(target)})}catch(e){location.href=${JSON.stringify(target)}}<\/script>`;
-
-  return new NextResponse(html, {
-    status: 302,
-    headers: {
-      Location: target,
-      'content-type': 'text/html; charset=utf-8',
-      'cache-control': 'no-store',
-    },
-  });
+  const to = uuid ? conversationDeepLinkFromUuid(uuid) : `${base}/conversation-not-found`;
+  return NextResponse.redirect(to, 302);
 }


### PR DESCRIPTION
## Summary
- route legacy conversation shortlink through the shared resolver so it accepts slugs and existing aliases
- simplify the redirect response to rely on the deep-link helper and return a standard 302
- allow alert emails to fall back to legacy/conversation shortlinks when a UUID cannot be resolved while keeping metrics intact

## Testing
- npm test *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c96d9e58cc832ab4de353cb1304d86