### PR TITLE
Add test covering legacy redirect when DB errors

### DIFF
--- a/tests/legacy-redirect-db-error.spec.ts
+++ b/tests/legacy-redirect-db-error.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+import { GET } from '../app/r/legacy/[id]/route';
+import { prisma } from '../lib/db';
+
+test('legacy redirect returns 302 even if DB throws', async () => {
+  const originalFindFirst = prisma.conversation.findFirst;
+  prisma.conversation.findFirst = async () => {
+    throw new Error('boom');
+  };
+
+  try {
+    const res = await GET(new Request('http://test/r/legacy/981137'), {
+      params: { id: '981137' },
+    });
+    expect([302, 307, 308]).toContain(res.status);
+  } finally {
+    prisma.conversation.findFirst = originalFindFirst;
+  }
+});


### PR DESCRIPTION
## Summary
- add a Playwright test verifying the legacy redirect still returns a redirect response even if Prisma throws
- restore the stubbed Prisma method after the test to avoid side effects

## Testing
- npm test *(fails: browserType.launch: Executable doesn't exist; requires `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68c9724c6cd0832a838ec27088664400