### PR TITLE
Resolver API for legacyId ➜ uuid (signed internal use)

### DIFF
--- a/apps/shared/lib/resolveSign.js
+++ b/apps/shared/lib/resolveSign.js
@@ -1,5 +1,19 @@
 import crypto from 'node:crypto';
-export function signResolve(id, ts, nonce, secret = process.env.RESOLVE_SECRET || '') {
-  const payload = `id=${id}&ts=${ts}&nonce=${nonce}`;
-  return crypto.createHmac('sha256', secret).update(payload).digest('hex');
+
+const DEFAULT_SECRET = () => process.env.RESOLVE_SECRET || '';
+
+function payload(id, ts, nonce) {
+  return `id=${id}&ts=${ts}&nonce=${nonce}`;
+}
+
+export function signResolve(id, ts, nonce, secret = DEFAULT_SECRET()) {
+  return crypto.createHmac('sha256', secret).update(payload(id, ts, nonce)).digest('hex');
+}
+
+export function verifyResolveSignature({ id, ts, nonce, sig, secret = DEFAULT_SECRET() }) {
+  const expected = signResolve(id, ts, nonce, secret);
+  const expectedBuf = Buffer.from(expected);
+  const provided = String(sig || '');
+  const providedBuf = Buffer.from(provided);
+  return expectedBuf.length === providedBuf.length && crypto.timingSafeEqual(expectedBuf, providedBuf);
 }

--- a/apps/shared/lib/resolveSign.ts
+++ b/apps/shared/lib/resolveSign.ts
@@ -1,5 +1,26 @@
 import crypto from 'node:crypto';
-export function signResolve(id: string, ts: number, nonce: string, secret = process.env.RESOLVE_SECRET || '') {
-  const payload = `id=${id}&ts=${ts}&nonce=${nonce}`;
-  return crypto.createHmac('sha256', secret).update(payload).digest('hex');
+
+const DEFAULT_SECRET = () => process.env.RESOLVE_SECRET || '';
+
+function payload(id: string, ts: number, nonce: string) {
+  return `id=${id}&ts=${ts}&nonce=${nonce}`;
+}
+
+export function signResolve(id: string, ts: number, nonce: string, secret = DEFAULT_SECRET()) {
+  return crypto.createHmac('sha256', secret).update(payload(id, ts, nonce)).digest('hex');
+}
+
+export function verifyResolveSignature(args: {
+  id: string;
+  ts: number;
+  nonce: string;
+  sig: string;
+  secret?: string;
+}) {
+  const { id, ts, nonce, sig, secret = DEFAULT_SECRET() } = args;
+  const expected = signResolve(id, ts, nonce, secret);
+  const expectedBuf = Buffer.from(expected);
+  const provided = String(sig || '');
+  const providedBuf = Buffer.from(provided);
+  return expectedBuf.length === providedBuf.length && crypto.timingSafeEqual(expectedBuf, providedBuf);
 }

--- a/apps/worker/mailer/alerts.tsx
+++ b/apps/worker/mailer/alerts.tsx
@@ -1,6 +1,7 @@
 import { makeConversationLink } from '../../shared/lib/links';
 import { makeLinkToken } from '../../shared/lib/linkToken';
 import { verifyConversationLink } from '../../shared/lib/verifyLink';
+import { signResolve } from '../../shared/lib/resolveSign';
 import { metrics } from '../../../lib/metrics';
 import crypto from 'node:crypto';
 
@@ -30,8 +31,7 @@ export async function buildAlertEmail(
     if (!secret) return null;
     const ts = Date.now();
     const nonce = crypto.randomBytes(8).toString('hex');
-    const payload = `id=${raw}&ts=${ts}&nonce=${nonce}`;
-    const sig = crypto.createHmac('sha256', secret).update(payload).digest('hex');
+    const sig = signResolve(raw, ts, nonce, secret);
     const url = `${host}/api/internal/resolve-conversation?id=${encodeURIComponent(raw)}&ts=${ts}&nonce=${nonce}&sig=${sig}`;
     try {
       const res = await fetch(url, { method: 'GET' });


### PR DESCRIPTION
Add /api/resolve/conversation?legacyId=... that returns {uuid}. Include HMAC signing helpers for internal use. Make tests pass: tests/resolve-conversation.spec.ts.

------
https://chatgpt.com/codex/tasks/task_e_68c99c28d5e8832a80afe6edede6df3b