### PR TITLE
Resolve conversation shortlink via alias records

### DIFF
--- a/apps/server/lib/conversations.js
+++ b/apps/server/lib/conversations.js
@@ -134,8 +134,17 @@ export async function tryResolveConversationUuid(idOrUuid, opts = {}) {
   try {
     const n = Number(raw);
     if (Number.isInteger(n)) {
+      attempted.push('alias-legacyId');
+      const alias = await prisma?.conversation_aliases?.findUnique?.({
+        where: { legacy_id: n },
+      });
+      if (alias?.uuid && isUuid(alias.uuid)) return alias.uuid.toLowerCase();
+
       attempted.push('db-legacyId');
-      const byNum = await prisma?.conversation?.findFirst?.({ where: { legacyId: n }, select: { uuid: true }});
+      const byNum = await prisma?.conversation?.findFirst?.({
+        where: { legacyId: n },
+        select: { uuid: true },
+      });
       if (byNum?.uuid && isUuid(byNum.uuid)) return byNum.uuid.toLowerCase();
     }
     attempted.push('db-slug');

--- a/tests/legacy-redirect.spec.ts
+++ b/tests/legacy-redirect.spec.ts
@@ -17,3 +17,24 @@ test('legacy redirect sends to conversation-not-found when uuid missing', async 
   expect(res.headers.get('location')).toBe('https://app.boomnow.com/conversation-not-found')
 })
 
+test('legacy redirect resolves via alias when conversation missing', async () => {
+  const uuid = '123e4567-e89b-12d3-a456-426614174111'
+  const legacyId = 4321
+  prisma.conversation_aliases._data.set(legacyId, {
+    legacy_id: legacyId,
+    uuid,
+    last_seen_at: new Date(),
+  })
+
+  const res = await GET(new Request(`http://test/r/legacy/${legacyId}`), {
+    params: { id: String(legacyId) },
+  })
+
+  expect(res.status).toBe(302)
+  expect(res.headers.get('location')).toBe(
+    `https://app.boomnow.com/dashboard/guest-experience/cs?conversation=${uuid}`
+  )
+
+  prisma.conversation_aliases._data.delete(legacyId)
+})
+


### PR DESCRIPTION
## Summary
- allow `tryResolveConversationUuid` to resolve numeric identifiers through `conversation_aliases`
- cover `/r/legacy/:id` with a regression test that exercises the alias fallback path

## Testing
- npm test -- legacy-redirect
- npm test *(fails: Playwright browser binaries are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d25fc2fc832aa051ff1882460f99