### PR TITLE
Normalize inbox redirects

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,28 +1,27 @@
 import type { NextRequest } from 'next/server.js';
 import { NextResponse } from 'next/server.js';
 
+function redirectToConversation(url: URL, conversation: string) {
+  const dest = new URL(url);
+  dest.pathname = '/dashboard/guest-experience/cs';
+  dest.searchParams.delete('cid');
+  dest.searchParams.set('conversation', conversation);
+  return NextResponse.redirect(dest, { status: 308 });
+}
+
 export function middleware(req: NextRequest) {
   const url = new URL(req.url);
 
   // Match /inbox?cid=...
   const cid = url.searchParams.get('cid');
   if (url.pathname === '/inbox' && cid) {
-    const dest = new URL('/dashboard/guest-experience/cs', url);
-    url.searchParams.forEach((v, k) => {
-      if (k !== 'cid') dest.searchParams.append(k, v);
-    });
-    dest.searchParams.set('conversation', cid);
-    return NextResponse.redirect(dest, { status: 308 });
+    return redirectToConversation(url, cid);
   }
 
   // Match /inbox/conversations/:id
   const inboxMatch = url.pathname.match(/^\/inbox\/conversations\/([^/]+)/);
   if (inboxMatch) {
-    const id = inboxMatch[1];
-    const dest = new URL('/dashboard/guest-experience/cs', url);
-    url.searchParams.forEach((v, k) => dest.searchParams.append(k, v));
-    dest.searchParams.set('conversation', id);
-    return NextResponse.redirect(dest, { status: 308 });
+    return redirectToConversation(url, inboxMatch[1]);
   }
 
   return NextResponse.next();

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -14,12 +14,32 @@ test('GET /inbox/conversations/123 -> 308 cs deep link', async () => {
   );
 });
 
+test('GET /inbox/conversations/123?cid=456 keeps extras but drops cid', async () => {
+  const req = new NextRequest(
+    'https://app.boomnow.com/inbox/conversations/123?cid=456&foo=bar'
+  );
+  const res = await middleware(req);
+  expect(res.status).toBe(308);
+  expect(res.headers.get('location')).toBe(
+    'https://app.boomnow.com/dashboard/guest-experience/cs?foo=bar&conversation=123'
+  );
+});
+
 test('middleware redirects legacy /inbox?cid=uuid to /c', async () => {
   const req = new NextRequest(`https://app.boomnow.com/inbox?cid=${uuid}`);
   const res = await middleware(req);
   expect(res.status).toBe(308);
   expect(res.headers.get('location')).toBe(
     `https://app.boomnow.com/dashboard/guest-experience/cs?conversation=${uuid}`
+  );
+});
+
+test('middleware retains extra params when redirecting legacy inbox', async () => {
+  const req = new NextRequest(`https://app.boomnow.com/inbox?cid=${uuid}&foo=bar`);
+  const res = await middleware(req);
+  expect(res.status).toBe(308);
+  expect(res.headers.get('location')).toBe(
+    `https://app.boomnow.com/dashboard/guest-experience/cs?foo=bar&conversation=${uuid}`
   );
 });
 


### PR DESCRIPTION
## Summary
- ensure the middleware rebuilds the deep-link destination from the original URL so it drops `cid` and keeps other query params
- add regression tests that cover preserving extra params and removing the legacy `cid` during redirects

## Testing
- npx playwright test tests/auth.spec.ts
- npm test *(fails: missing Playwright browsers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e5013920832a81eeb8585896c90c