### PR TITLE
Ignore unapproved AI drafts in SLA evaluator

### DIFF
--- a/tests/sla-evaluator.spec.ts
+++ b/tests/sla-evaluator.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+
+const IMPORT_PATH = '../check.mjs';
+
+let evaluate: any;
+
+test.beforeAll(async () => {
+  process.env.COUNT_AI_SUGGESTION_AS_AGENT = 'false';
+  (globalThis as any).__CHECK_TEST__ = true;
+  const mod = await import(IMPORT_PATH);
+  delete (globalThis as any).__CHECK_TEST__;
+  evaluate = mod.evaluate;
+});
+
+test.afterAll(() => {
+  delete process.env.COUNT_AI_SUGGESTION_AS_AGENT;
+});
+
+test.beforeEach(() => {
+  (globalThis as any).translate = async () => ({ text: '' });
+});
+
+test.afterEach(() => {
+  delete (globalThis as any).translate;
+});
+
+function iso(date: string) {
+  return new Date(date);
+}
+
+test('internal notes do not satisfy the SLA window', async () => {
+  const now = iso('2024-01-01T00:10:00Z');
+  const messages = [
+    { sent_at: '2024-01-01T00:00:00Z', by: 'guest', direction: 'inbound', body: 'Hello there' },
+    { sent_at: '2024-01-01T00:02:00Z', senderType: 'system', module: 'workflow', msg_type: 'status_change', body: 'Status updated internally' },
+  ];
+  const result = await evaluate(messages, now, 5);
+  expect(result.ok).toBe(false);
+  expect(result.reason).toBe('guest_unanswered');
+});
+
+test('unapproved AI suggestions are ignored', async () => {
+  const now = iso('2024-01-01T00:10:00Z');
+  const messages = [
+    { sent_at: '2024-01-01T00:00:00Z', by: 'guest', direction: 'inbound', body: 'Hello there' },
+    {
+      sent_at: '2024-01-01T00:03:00Z',
+      generated_by_ai: true,
+      ai_status: 'draft',
+      by: 'agent',
+      direction: 'outbound',
+      body: 'Proposed reply from AI',
+    },
+  ];
+  const result = await evaluate(messages, now, 5);
+  expect(result.ok).toBe(false);
+  expect(result.reason).toBe('guest_unanswered');
+});
+
+test('approved AI responses clear the SLA', async () => {
+  const now = iso('2024-01-01T00:10:00Z');
+  const messages = [
+    { sent_at: '2024-01-01T00:00:00Z', by: 'guest', direction: 'inbound', body: 'Hello there' },
+    {
+      sent_at: '2024-01-01T00:04:00Z',
+      generated_by_ai: true,
+      ai_status: 'approved',
+      by: 'agent',
+      direction: 'outbound',
+      body: 'Approved and sent reply',
+    },
+  ];
+  const result = await evaluate(messages, now, 5);
+  expect(result.ok).toBe(true);
+  expect(result.reason).toBe('no_breach');
+});


### PR DESCRIPTION
## Summary
- skip internal messages and AI drafts without approval when computing the SLA window
- guard the check runner during tests and export evaluator helpers for reuse
- add tests that cover internal notes, unapproved AI drafts, and approved AI replies

## Testing
- npm test *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e8a9c004832aa422d3865963d97a