### PR TITLE
refactor: share internal resolver util

### DIFF
--- a/cron.mjs
+++ b/cron.mjs
@@ -1,6 +1,5 @@
 // --- auth + logging + email helpers ---
 import { spawn } from "node:child_process";
-import crypto from "node:crypto";
 import nodemailer from "nodemailer";
 import { isDuplicateAlert, markAlerted, dedupeKey } from "./dedupe.mjs";
 import { selectTop50, assertTop50 } from "./src/lib/selectTop50.js";
@@ -8,31 +7,10 @@ import { makeConversationLink, conversationIdDisplay, appUrl } from "./lib/links
 import { tryResolveConversationUuid } from "./apps/server/lib/conversations.js";
 import { prisma } from "./lib/db.js";
 import { isClosingStatement } from "./src/lib/isClosingStatement.js";
-import { signResolve } from "./apps/shared/lib/resolveSign.js";
+import { resolveViaInternalEndpoint } from "./lib/internalResolve.js";
+export { resolveViaInternalEndpoint } from "./lib/internalResolve.js";
 const logger = console;
 const metrics = { increment: () => {} };
-const RESOLVE_BASE_URL = process.env.RESOLVE_BASE_URL || process.env.APP_URL || 'https://app.boomnow.com';
-const RESOLVE_SECRET = process.env.RESOLVE_SECRET || '';
-
-export async function resolveViaInternalEndpoint(idOrSlug) {
-  if (!RESOLVE_SECRET) return null;
-  const ts = Date.now();
-  const nonce = crypto.randomBytes(8).toString('hex');
-  const id = String(idOrSlug);
-  const params = new URLSearchParams({ id, ts: String(ts), nonce });
-  const sig = signResolve(id, ts, nonce, RESOLVE_SECRET);
-  params.set('sig', sig);
-  const base = RESOLVE_BASE_URL.endsWith('/') ? RESOLVE_BASE_URL.slice(0, -1) : RESOLVE_BASE_URL;
-  const url = `${base}/api/internal/resolve-conversation?${params.toString()}`;
-  try {
-    const res = await fetch(url, { method: 'GET' });
-    if (!res.ok) return null;
-    const { uuid } = await res.json();
-    return /^[0-9a-f-]{36}$/i.test(uuid) ? uuid.toLowerCase() : null;
-  } catch {
-    return null;
-  }
-}
 // Assumes ESM. Node 18+ provides global fetch. If you're on older Node, ensure node-fetch is installed & imported.
 
 // Build a safe user-facing link: prefer deep link with UUID, else shortlink that the app resolves.

--- a/lib/internalResolve.js
+++ b/lib/internalResolve.js
@@ -1,0 +1,25 @@
+import crypto from "node:crypto";
+import { signResolve } from "../apps/shared/lib/resolveSign.js";
+
+const RESOLVE_BASE_URL = process.env.RESOLVE_BASE_URL || process.env.APP_URL || "https://app.boomnow.com";
+const RESOLVE_SECRET = process.env.RESOLVE_SECRET || "";
+
+export async function resolveViaInternalEndpoint(idOrSlug) {
+  if (!RESOLVE_SECRET) return null;
+  const ts = Date.now();
+  const nonce = crypto.randomBytes(8).toString("hex");
+  const id = String(idOrSlug);
+  const params = new URLSearchParams({ id, ts: String(ts), nonce });
+  const sig = signResolve(id, ts, nonce, RESOLVE_SECRET);
+  params.set("sig", sig);
+  const base = RESOLVE_BASE_URL.endsWith("/") ? RESOLVE_BASE_URL.slice(0, -1) : RESOLVE_BASE_URL;
+  const url = `${base}/api/internal/resolve-conversation?${params.toString()}`;
+  try {
+    const res = await fetch(url, { method: "GET" });
+    if (!res.ok) return null;
+    const { uuid } = await res.json();
+    return /^[0-9a-f-]{36}$/i.test(uuid) ? uuid.toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- move the internal resolveViaInternalEndpoint helper into a shared lib
- reuse the helper from the cron script and fall back to it inside the check script

## Testing
- npm test *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9eb19bff4832aa4c4900da4bf205d