### PR TITLE
Add universal conversation link helper

### DIFF
--- a/apps/worker/mailer/alerts.tsx
+++ b/apps/worker/mailer/alerts.tsx
@@ -1,9 +1,6 @@
-import { makeConversationLink } from '../../shared/lib/links';
-import { makeLinkToken } from '../../shared/lib/linkToken';
 import { verifyConversationLink } from '../../shared/lib/verifyLink';
-import { signResolve } from '../../shared/lib/resolveSign';
 import { metrics } from '../../../lib/metrics';
-import crypto from 'node:crypto';
+import { buildUniversalConversationLink } from '../../../lib/alertLink.js';
 
 export async function buildAlertEmail(
   event: { conversation_uuid?: string; legacyId?: number | string; slug?: string },
@@ -13,80 +10,45 @@ export async function buildAlertEmail(
   const preferVerify = deps?.verify ?? verifyConversationLink;
   const base = (process.env.APP_URL || 'https://app.boomnow.com').replace(/\/+$/, '');
 
-  // 1) Prefer UUID present on the event
-  let uuid = typeof event?.conversation_uuid === 'string' ? event.conversation_uuid : null;
+  const uuid = typeof event?.conversation_uuid === 'string' ? event.conversation_uuid : undefined;
+  const hasFallback = event?.legacyId != null || typeof event?.slug === 'string';
 
-  const fallbackRaw = (() => {
-    if (event?.legacyId != null) return String(event.legacyId).trim();
-    if (typeof event?.slug === 'string') return event.slug.trim();
-    return '';
-  })();
-
-  // 2) If missing, resolve at *send time* via internal signed endpoint
-  async function resolveUuid(idOrSlug: string): Promise<string | null> {
-    const raw = (idOrSlug || '').trim();
-    if (!raw) return null;
-    const secret = process.env.RESOLVE_SECRET || '';
-    const host = (process.env.RESOLVE_BASE_URL || process.env.APP_URL || base).replace(/\/+$/, '');
-    if (!secret) return null;
-    const ts = Date.now();
-    const nonce = crypto.randomBytes(8).toString('hex');
-    const sig = signResolve(raw, ts, nonce, secret);
-    const url = `${host}/api/internal/resolve-conversation?id=${encodeURIComponent(raw)}&ts=${ts}&nonce=${nonce}&sig=${sig}`;
-    try {
-      const res = await fetch(url, { method: 'GET' });
-      if (!res.ok) return null;
-      const json = await res.json().catch(() => null);
-      const u = json?.uuid;
-      return typeof u === 'string' && /^[0-9a-f-]{36}$/i.test(u) ? u.toLowerCase() : null;
-    } catch {
-      return null;
-    }
-  }
-
-  if (!uuid && fallbackRaw) {
-    uuid = await resolveUuid(fallbackRaw);
-  }
-
-  if (!uuid && !fallbackRaw) {
+  if (!uuid && !hasFallback) {
     logger?.warn?.({ event }, 'skip alert: missing resolvable uuid');
     metrics.increment('alerts.skipped_missing_uuid');
     return null;
   }
 
-  const fallbackUrl = fallbackRaw
-    ? `${base}${/^[0-9]+$/.test(fallbackRaw) ? '/r/legacy/' : '/r/conversation/'}${encodeURIComponent(fallbackRaw)}`
-    : null;
-
-  // 3) Mint a short token link that is self-contained and DB-independent on click
-  let url: string | null = null;
-  try {
-    const exp = Math.floor(Date.now() / 1000) + 7 * 24 * 3600; // 7 days
-    if (uuid) {
-      const token = makeLinkToken({ uuid, exp });
-      url = `${base}/r/t/${token}`;
+  let verifyFailed = false;
+  const link = await buildUniversalConversationLink(
+    { uuid, legacyId: event?.legacyId, slug: event?.slug },
+    {
+      baseUrl: base,
+      verify: async (url: string) => {
+        const ok = await preferVerify(url);
+        if (!ok) {
+          verifyFailed = true;
+          logger?.warn?.({ url }, 'link_verification_failed');
+        }
+        return ok;
+      },
+      onTokenError: (err: unknown) => {
+        logger?.warn?.({ uuid, err }, 'link_token_generation_failed');
+      },
     }
-  } catch (err) {
-    logger?.warn?.({ uuid, err }, 'link_token_generation_failed');
-  }
-  if (!url && uuid) url = makeConversationLink({ uuid });
-  let legacyFallback = false;
-  if (!url && fallbackUrl) {
-    url = fallbackUrl;
-    legacyFallback = true;
-  }
-  if (!url) {
-    logger?.warn?.({ event }, 'skip alert: unable to build link');
+  );
+
+  if (!link) {
     metrics.increment('alerts.skipped_link_preflight');
+    if (verifyFailed) {
+      return null;
+    }
+    logger?.warn?.({ event }, 'skip alert: unable to build link');
     return null;
   }
 
-  const ok = await preferVerify(url);
-  if (!ok) {
-    logger?.warn?.({ url }, 'link_verification_failed');
-    metrics.increment('alerts.skipped_link_preflight');
-    return null;
-  }
-  metrics.increment(legacyFallback ? 'alerts.sent_with_legacy_shortlink' : 'alerts.sent_with_uuid');
-  return `<p>Alert for conversation <a href="${url}">${url}</a></p>`;
+  metrics.increment(
+    link.kind === 'legacy' ? 'alerts.sent_with_legacy_shortlink' : 'alerts.sent_with_uuid'
+  );
+  return `<p>Alert for conversation <a href="${link.url}">${link.url}</a></p>`;
 }

--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -1,0 +1,108 @@
+import crypto from 'node:crypto';
+import { appUrl } from './links.js';
+import { makeLinkToken } from './linkToken.js';
+import { signResolve } from '../apps/shared/lib/resolveSign.js';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+async function defaultVerify(url) {
+  try {
+    const res = await fetch(url, { method: 'GET', redirect: 'manual' });
+    if (res.status === 200) return true;
+    if (res.status >= 300 && res.status < 400) {
+      const loc = res.headers.get('location') || '';
+      if (loc.includes('/login') || loc.includes('/dashboard/guest-experience/cs')) {
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveUuid(idOrSlug, base) {
+  const raw = String(idOrSlug || '').trim();
+  if (!raw) return null;
+  const secret = process.env.RESOLVE_SECRET || '';
+  const host = (process.env.RESOLVE_BASE_URL || base).replace(/\/+$/, '');
+  if (!secret) return null;
+  const ts = Date.now();
+  const nonce = crypto.randomBytes(8).toString('hex');
+  const sig = signResolve(raw, ts, nonce, secret);
+  const url = `${host}/api/internal/resolve-conversation?id=${encodeURIComponent(
+    raw
+  )}&ts=${ts}&nonce=${nonce}&sig=${sig}`;
+  try {
+    const res = await fetch(url, { method: 'GET' });
+    if (!res.ok) return null;
+    const json = await res.json().catch(() => null);
+    const u = json?.uuid;
+    return typeof u === 'string' && UUID_RE.test(u) ? u.toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a verified, user-safe conversation link.
+ * Returns { url, kind } or null if we cannot produce a verified link.
+ */
+export async function buildUniversalConversationLink(input = {}, opts = {}) {
+  const base = (opts.baseUrl || appUrl()).replace(/\/+$/, '');
+  const verify = opts.verify || defaultVerify;
+  const onTokenError =
+    typeof opts.onTokenError === 'function'
+      ? (err, context) => {
+          try {
+            opts.onTokenError(err, context);
+          } catch {
+            // ignore handler errors
+          }
+        }
+      : null;
+
+  let uuid =
+    typeof input?.uuid === 'string' && UUID_RE.test(input.uuid)
+      ? input.uuid.toLowerCase()
+      : null;
+
+  const fallbackRaw =
+    input?.legacyId != null
+      ? String(input.legacyId).trim()
+      : typeof input?.slug === 'string'
+      ? input.slug.trim()
+      : '';
+
+  if (!uuid && fallbackRaw) {
+    uuid = await resolveUuid(fallbackRaw, base);
+  }
+
+  let url = null;
+  let kind = 'uuid';
+
+  if (uuid) {
+    // Prefer a short token link; fall back to deep link if token mint fails
+    try {
+      const exp = Math.floor(Date.now() / 1000) + 7 * 24 * 3600;
+      const token = makeLinkToken({ uuid, exp });
+      url = `${base}/r/t/${token}`;
+    } catch (err) {
+      onTokenError?.(err, { uuid });
+      url = `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(
+        uuid
+      )}`;
+    }
+  } else if (fallbackRaw) {
+    url = `${base}${
+      /^[0-9]+$/.test(fallbackRaw) ? '/r/legacy/' : '/r/conversation/'
+    }${encodeURIComponent(fallbackRaw)}`;
+    kind = 'legacy';
+  }
+
+  if (!url) return null;
+  const ok = await verify(url);
+  if (!ok) return null;
+  return { url, kind };
+}

--- a/tests/alert-link.spec.ts
+++ b/tests/alert-link.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect } from '@playwright/test';
+import { buildUniversalConversationLink } from '../lib/alertLink.js';
+import { verifyLinkToken } from '../apps/shared/lib/linkToken';
+
+const ORIGINAL_LINK_SECRET = process.env.LINK_SECRET;
+const ORIGINAL_RESOLVE_SECRET = process.env.RESOLVE_SECRET;
+const ORIGINAL_RESOLVE_BASE_URL = process.env.RESOLVE_BASE_URL;
+const ORIGINAL_APP_URL = process.env.APP_URL;
+const ORIGINAL_FETCH = global.fetch;
+
+const uuid = '123e4567-e89b-12d3-a456-426614174000';
+
+function restoreEnv() {
+  if (ORIGINAL_LINK_SECRET !== undefined) {
+    process.env.LINK_SECRET = ORIGINAL_LINK_SECRET;
+  } else {
+    delete process.env.LINK_SECRET;
+  }
+  if (ORIGINAL_RESOLVE_SECRET !== undefined) {
+    process.env.RESOLVE_SECRET = ORIGINAL_RESOLVE_SECRET;
+  } else {
+    delete process.env.RESOLVE_SECRET;
+  }
+  if (ORIGINAL_RESOLVE_BASE_URL !== undefined) {
+    process.env.RESOLVE_BASE_URL = ORIGINAL_RESOLVE_BASE_URL;
+  } else {
+    delete process.env.RESOLVE_BASE_URL;
+  }
+  if (ORIGINAL_APP_URL !== undefined) {
+    process.env.APP_URL = ORIGINAL_APP_URL;
+  } else {
+    delete process.env.APP_URL;
+  }
+  if (ORIGINAL_FETCH) {
+    global.fetch = ORIGINAL_FETCH;
+  } else {
+    delete (global as any).fetch;
+  }
+}
+
+test.afterEach(() => {
+  restoreEnv();
+});
+
+const BASE = 'https://example.com';
+
+test('buildUniversalConversationLink returns token link for uuid', async () => {
+  process.env.LINK_SECRET = 'test-secret';
+  const res = await buildUniversalConversationLink(
+    { uuid },
+    {
+      baseUrl: BASE,
+      verify: async (url) => {
+        expect(url.startsWith(`${BASE}/r/t/`)).toBe(true);
+        return true;
+      },
+    }
+  );
+  expect(res?.kind).toBe('uuid');
+  expect(res?.url).toBeDefined();
+  const href = res?.url ?? '';
+  const parsed = new URL(href);
+  expect(parsed.pathname.startsWith('/r/t/')).toBe(true);
+  const token = parsed.pathname.split('/').pop();
+  expect(token).toBeTruthy();
+  const decoded = token ? verifyLinkToken(token) : { error: 'invalid' };
+  expect('uuid' in decoded ? decoded.uuid : null).toBe(uuid);
+});
+
+test('buildUniversalConversationLink falls back to deep link when token mint fails', async () => {
+  delete process.env.LINK_SECRET;
+  const calls: unknown[] = [];
+  const res = await buildUniversalConversationLink(
+    { uuid },
+    {
+      baseUrl: BASE,
+      verify: async (url) => {
+        calls.push(url);
+        expect(url).toBe(
+          `${BASE}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(uuid)}`
+        );
+        return true;
+      },
+      onTokenError: (err) => {
+        calls.push(err);
+      },
+    }
+  );
+  expect(res?.kind).toBe('uuid');
+  expect(res?.url).toBe(
+    `${BASE}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(uuid)}`
+  );
+  expect(calls.length).toBeGreaterThanOrEqual(2);
+});
+
+test('buildUniversalConversationLink returns legacy shortlink when uuid unavailable', async () => {
+  process.env.LINK_SECRET = 'test-secret';
+  delete process.env.RESOLVE_SECRET;
+  delete process.env.RESOLVE_BASE_URL;
+  const res = await buildUniversalConversationLink(
+    { legacyId: 456 },
+    {
+      baseUrl: BASE,
+      verify: async (url) => {
+        expect(url).toBe(`${BASE}/r/legacy/456`);
+        return true;
+      },
+    }
+  );
+  expect(res).toEqual({ url: `${BASE}/r/legacy/456`, kind: 'legacy' });
+});
+
+test('buildUniversalConversationLink uses slug when numeric id missing', async () => {
+  process.env.LINK_SECRET = 'test-secret';
+  const res = await buildUniversalConversationLink(
+    { slug: 'my-convo' },
+    {
+      baseUrl: BASE,
+      verify: async (url) => {
+        expect(url).toBe(`${BASE}/r/conversation/my-convo`);
+        return true;
+      },
+    }
+  );
+  expect(res).toEqual({ url: `${BASE}/r/conversation/my-convo`, kind: 'legacy' });
+});
+
+test('buildUniversalConversationLink resolves identifiers via internal endpoint', async () => {
+  process.env.LINK_SECRET = 'test-secret';
+  process.env.RESOLVE_SECRET = 'resolve';
+  process.env.RESOLVE_BASE_URL = 'https://resolve.test';
+  const fetchCalls: string[] = [];
+  global.fetch = async (url: any) => {
+    fetchCalls.push(String(url));
+    return { ok: true, json: async () => ({ uuid }) } as any;
+  };
+  const res = await buildUniversalConversationLink(
+    { legacyId: 'abc' },
+    {
+      baseUrl: BASE,
+      verify: async (url) => {
+        expect(url.startsWith(`${BASE}/r/t/`)).toBe(true);
+        return true;
+      },
+    }
+  );
+  expect(res?.kind).toBe('uuid');
+  expect(fetchCalls[0]).toContain('id=abc');
+});
+
+test('buildUniversalConversationLink returns null when verification fails', async () => {
+  process.env.LINK_SECRET = 'test-secret';
+  const res = await buildUniversalConversationLink(
+    { uuid },
+    {
+      baseUrl: BASE,
+      verify: async () => false,
+    }
+  );
+  expect(res).toBeNull();
+});


### PR DESCRIPTION
## Summary
- add a universal conversation link builder that resolves legacy identifiers, mints tokens, and verifies links
- refactor the alert mailer to use the shared helper while preserving logging and metrics behaviour
- add Playwright unit tests covering the helper’s token, fallback, and resolver flows

## Testing
- npm test *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f3f30b88832a90a7f4728d3da7dc