### PR TITLE
Use repository variables for Boom URLs in workflows

### DIFF
--- a/.github/workflows/boom-check.yml
+++ b/.github/workflows/boom-check.yml
@@ -15,7 +15,8 @@ jobs:
       SLA_MINUTES:     ${{ vars.SLA_MINUTES }}
       DEBUG:           ${{ vars.DEBUG }}
       DEBUG_MESSAGES:  ${{ vars.DEBUG_MESSAGES }}
-      APP_URL: https://app.boomnow.com
+      APP_URL: ${{ vars.APP_URL }}
+      RESOLVE_BASE_URL: ${{ vars.RESOLVE_BASE_URL }}
       SMTP_HOST:       ${{ secrets.SMTP_HOST }}
       SMTP_PORT:       ${{ secrets.SMTP_PORT }}
       SMTP_USER:       ${{ secrets.SMTP_USER }}

--- a/.github/workflows/boom-cron.yml
+++ b/.github/workflows/boom-cron.yml
@@ -39,7 +39,8 @@ jobs:
       BACKFILL_CONCURRENCY:       ${{ vars.BACKFILL_CONCURRENCY }}
       TOTAL_CONVERSATIONS_ESTIMATE: ${{ vars.TOTAL_CONVERSATIONS_ESTIMATE }}
       MAX_CONCURRENCY:            ${{ vars.MAX_CONCURRENCY }}
-      APP_URL: https://app.boomnow.com
+      APP_URL: ${{ vars.APP_URL }}
+      RESOLVE_BASE_URL: ${{ vars.RESOLVE_BASE_URL }}
       RESOLVE_SECRET: ${{ secrets.RESOLVE_SECRET }}
       LIST_SORT_FIELD:            ${{ vars.LIST_SORT_FIELD }}
       LIST_SORT_ORDER_RECENT:     ${{ vars.LIST_SORT_ORDER_RECENT }}


### PR DESCRIPTION
## Summary
- read the Boom app URL from repository variables in both SLA workflows
- expose the resolve base URL alongside the existing secrets

## Testing
- not run (CI configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68ca6cc9d898832ab8fac715c7a436e2