### PR TITLE
Sanitize control characters in app URL

### DIFF
--- a/lib/links.js
+++ b/lib/links.js
@@ -1,12 +1,17 @@
 export const trim = (s) => s.replace(/\/+$/, '')
+const stripCtlAndTrim = (s) =>
+  String(s ?? '')
+    .replace(/[\u0000-\u001F\u007F]/g, '')
+    .trim()
 
-export const appUrl = () => trim(process.env.APP_URL ?? 'https://app.boomnow.com')
+export const appUrl = () =>
+  trim(stripCtlAndTrim(process.env.APP_URL ?? 'https://app.boomnow.com'))
 
 const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i
 
 const normalizeBaseUrl = (input) => {
-  if (!input) return appUrl()
-  return trim(String(input))
+  const raw = input ? String(input) : appUrl()
+  return trim(stripCtlAndTrim(raw))
 }
 
 export function makeConversationLink({ uuid, baseUrl }) {


### PR DESCRIPTION
## Summary
- strip control characters and surrounding whitespace from APP_URL before trimming slashes
- reuse the new sanitizer when normalizing base URLs passed into link helpers

## Testing
- npm test *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7541004c832aa421a53c0f546e3d