### PR TITLE
Sanitize APP_URL env before building links

### DIFF
--- a/apps/shared/lib/links.ts
+++ b/apps/shared/lib/links.ts
@@ -1,4 +1,4 @@
-const trim = (s: string) => s.replace(/\/+$/, '')
+const trim = (s: string) => s.trim().replace(/\/+$/, '')
 
 export const appUrl = () => trim(process.env.APP_URL ?? 'https://app.boomnow.com')
 

--- a/tests/app-url-sanitize.spec.ts
+++ b/tests/app-url-sanitize.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test('APP_URL with CR/LF produces clean, single-line links', async () => {
+  const OLD = process.env.APP_URL;
+  process.env.APP_URL = 'https://app.boomnow.com\r\n';
+
+  const { appUrl, makeConversationLink } = await import('../apps/shared/lib/links');
+  const { buildSafeDeepLink } = await (async () => {
+    (globalThis as any).__CRON_TEST__ = true;
+    const mod = await import('../cron.mjs');
+    delete (globalThis as any).__CRON_TEST__;
+    return mod as any;
+  })();
+
+  expect(appUrl()).toBe('https://app.boomnow.com');
+  const uuid = '123e4567-e89b-12d3-a456-426614174000';
+  const deep = makeConversationLink({ uuid });
+  expect(deep).toBe('https://app.boomnow.com/dashboard/guest-experience/cs?conversation=123e4567-e89b-12d3-a456-426614174000');
+  const fallback = buildSafeDeepLink('991130', null);
+  expect(fallback).toBe('https://app.boomnow.com/r/legacy/991130');
+
+  if (OLD !== undefined) process.env.APP_URL = OLD; else delete process.env.APP_URL;
+});


### PR DESCRIPTION
## Summary
- add a regression test to ensure APP_URL values with CR/LF are sanitized
- trim whitespace from APP_URL-derived inputs before removing trailing slashes

## Testing
- npx playwright test tests/app-url-sanitize.spec.ts
- npm test *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca76be4afc832a8c320a37e2a70be5