### PR TITLE
Bridge TypeScript resolver to JS implementation

### DIFF
--- a/apps/server/lib/conversations.ts
+++ b/apps/server/lib/conversations.ts
@@ -1,6 +1,15 @@
-import { isUuid } from '../../shared/lib/uuid';
+/*
+ * TypeScript bridge that re-exports the robust JS implementation.
+ * This prevents accidental use of a stub and guarantees consistent behavior
+ * across TS/JS call-sites.
+ */
+export type ResolveOpts = {
+  inlineThread?: unknown;
+  fetchFirstMessage?: (idOrSlug: string) => Promise<unknown> | unknown;
+  skipRedirectProbe?: boolean;
+  onDebug?: (d: unknown) => void;
+};
 
-export async function tryResolveConversationUuid(idOrUuid: string): Promise<string | null> {
-  const id = String(idOrUuid ?? '');
-  return isUuid(id) ? id.toLowerCase() : null;
-}
+// Runtime implementation (DB lookups, alias mining, redirect/message probes)
+// lives in the JS file and is shared by Node scripts and Next runtime.
+export { tryResolveConversationUuid } from './conversations.js';


### PR DESCRIPTION
## Summary
- replace the stubbed TypeScript resolver with a bridge that re-exports the shared JavaScript implementation to keep behavior consistent across runtimes

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cab8234ee0832abf34a1e43ea1bcca