### PR TITLE
Handle broader redirect responses when verifying conversation links

### DIFF
--- a/apps/shared/lib/verifyLink.ts
+++ b/apps/shared/lib/verifyLink.ts
@@ -5,10 +5,10 @@ export async function verifyConversationLink(url: string): Promise<boolean> {
       // Direct deep link rendered (SPA shell)
       return true;
     }
-    if (res.status !== 302) return false;
-    const loc = res.headers.get('location') ?? '';
-    if (loc.includes('/login') || loc.includes('/dashboard/guest-experience/cs')) {
-      return true;
+    // Accept any 3xx; verify Location header points to our login or deep link path
+    if (res.status >= 300 && res.status < 400) {
+      const loc = res.headers.get('location') ?? '';
+      return /\/login\b|\/dashboard\/guest-experience\/cs\b/.test(loc);
     }
     return false;
   } catch {


### PR DESCRIPTION
## Summary
- allow verifyConversationLink to treat all 3xx responses as potential success
- validate redirect targets with a regex for the login or customer support deep link

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cab97ac260832a88f848348aa0f8bf