### PR TITLE
Add tests for verifyConversationLink redirect handling

### DIFF
--- a/tests/verify-link-redirects.spec.ts
+++ b/tests/verify-link-redirects.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import { verifyConversationLink } from '../apps/shared/lib/verifyLink';
+
+test('verifyConversationLink accepts 303/307/308 to login or deep link', async () => {
+  const orig = global.fetch;
+  function fake(status: number, location?: string) {
+    return async () =>
+      ({
+        status,
+        headers: new Map(location ? [['location', location]] : []),
+      } as any);
+  }
+  try {
+    global.fetch = fake(303, 'https://app.boomnow.com/login');
+    await expect(verifyConversationLink('https://example.com/x')).resolves.toBe(true);
+
+    global.fetch = fake(
+      307,
+      'https://app.boomnow.com/dashboard/guest-experience/cs?conversation=123e4567-e89b-12d3-a456-426614174000',
+    );
+    await expect(verifyConversationLink('https://example.com/x')).resolves.toBe(true);
+
+    // 308 with unrelated location -> false
+    global.fetch = fake(308, 'https://app.boomnow.com/somewhere-else');
+    await expect(verifyConversationLink('https://example.com/x')).resolves.toBe(false);
+  } finally {
+    global.fetch = orig as any;
+  }
+});


### PR DESCRIPTION
## Summary
- add coverage for verifyConversationLink redirect handling of 303, 307, and 308 responses
- ensure redirects are accepted only when the Location header targets login or deep-link destinations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68caba3d4bbc832a8776f14f16836615