### PR TITLE
Add TS bridge test for conversation UUID resolver

### DIFF
--- a/tests/resolve-uuid-ts-bridge.spec.ts
+++ b/tests/resolve-uuid-ts-bridge.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import { tryResolveConversationUuid } from '../apps/server/lib/conversations'; // TS bridge
+
+const UUID = '123e4567-e89b-12d3-a456-426614174000';
+
+test('TS conversations.ts re-exports robust JS implementation (redirect-probe works)', async () => {
+  const OLD = global.fetch;
+  try {
+    // Simulate redirect-probe path returning deep link with UUID
+    global.fetch = (async () =>
+      ({
+        headers: new Map([
+          ['location', `https://app.boomnow.com/dashboard/guest-experience/cs?conversation=${UUID}`],
+        ]),
+        text: async () => '',
+      } as any)) as any;
+    const got = await tryResolveConversationUuid('991130', {});
+    expect(got).toBe(UUID);
+  } finally {
+    global.fetch = OLD as any;
+  }
+});


### PR DESCRIPTION
## Summary
- add a Playwright test to ensure the TypeScript conversations bridge re-exports the robust JS resolver

## Testing
- npm test *(fails: Playwright browsers not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68cabbb3ba08832aadbfad283686fe41