### PR TITLE
Update cron fallback to dashboard filters

### DIFF
--- a/tests/app-url-sanitize.spec.ts
+++ b/tests/app-url-sanitize.spec.ts
@@ -17,7 +17,7 @@ test('APP_URL with CR/LF produces clean, single-line links', async () => {
   const deep = makeConversationLink({ uuid });
   expect(deep).toBe('https://app.boomnow.com/dashboard/guest-experience/all?conversation=123e4567-e89b-12d3-a456-426614174000');
   const fallback = buildSafeDeepLink('991130', null);
-  expect(fallback).toBe('https://app.boomnow.com/r/legacy/991130');
+  expect(fallback).toBe('https://app.boomnow.com/dashboard/guest-experience/all?legacyId=991130');
 
   if (OLD !== undefined) process.env.APP_URL = OLD; else delete process.env.APP_URL;
 });

--- a/tests/cron-fallback-link.spec.ts
+++ b/tests/cron-fallback-link.spec.ts
@@ -7,7 +7,7 @@ test('cron fallback builds shortlinks when UUID is unavailable', async () => {
   delete (globalThis as any).__CRON_TEST__;
   const { buildSafeDeepLink } = mod as any;
   const a = buildSafeDeepLink('991130', null);
-  expect(a).toMatch(/\/r\/legacy\/991130$/);
+  expect(a).toMatch(/dashboard\/guest-experience\/all\?legacyId=991130$/);
   const b = buildSafeDeepLink('abc-slug', null);
-  expect(b).toMatch(/\/r\/conversation\/abc-slug$/);
+  expect(b).toMatch(/dashboard\/guest-experience\/all\?conversation=abc-slug$/);
 });

--- a/tests/legacy-redirect.spec.ts
+++ b/tests/legacy-redirect.spec.ts
@@ -11,10 +11,12 @@ test('legacy redirect resolves to uuid deep link', async () => {
   expect(res.headers.get('location')).toBe(`https://app.boomnow.com/dashboard/guest-experience/all?conversation=${uuid}`)
 })
 
-test('legacy redirect sends to conversation-not-found when uuid missing', async () => {
+test('legacy redirect sends to dashboard filter when uuid missing', async () => {
   const res = await GET(new Request('http://test/r/legacy/999'), { params: { id: '999' } })
   expect(res.status).toBe(302)
-  expect(res.headers.get('location')).toBe('https://app.boomnow.com/conversation-not-found')
+  expect(res.headers.get('location')).toBe(
+    'https://app.boomnow.com/dashboard/guest-experience/all?legacyId=999',
+  )
 })
 
 test('legacy redirect resolves via alias when conversation missing', async () => {


### PR DESCRIPTION
## Summary
- build cron fallback links with makeConversationLink and dashboard query parameters
- update fallback expectations in cron and legacy redirect tests

## Testing
- npm test *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cad927f604832a81553d793a19f18d