### PR TITLE
Redirect CS conversation view to all page

### DIFF
--- a/app/dashboard/guest-experience/cs/page.tsx
+++ b/app/dashboard/guest-experience/cs/page.tsx
@@ -82,13 +82,20 @@ export default function CsPage() {
     }
   }, [numericLegacyId, numericConversation, router, uuid]);
 
+  useEffect(() => {
+    if (uuid) {
+      const url = `/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`;
+      router.replace(url, { scroll: false });
+    }
+  }, [uuid, router]);
+
   if (notFound) {
     return <div style={{ padding: 16 }}>Conversation not found or has been deleted.</div>;
   }
 
-  if (!uuid && (legacyId || numericConversation || resolving)) {
-    return <div style={{ padding: 16 }}>Opening conversation…</div>;
-  }
-
-  return <div data-uuid={uuid ?? ''}>Conversation {uuid}</div>;
+  return (
+    <div style={{ padding: 16 }}>
+      {resolving || legacyId || numericConversation ? 'Opening conversation…' : 'Conversation'}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- redirect the CS conversation page to the main guest experience conversation UI once a UUID is available
- fall back to a simple status message while a conversation is resolving or missing

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68cadaba0fa4832ab5482ff103547dc4