### PR TITLE
Update GE redirect e2e test description

### DIFF
--- a/e2e/ge-cs-redirect.spec.ts
+++ b/e2e/ge-cs-redirect.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import { startTestServer, stopTestServer } from '../tests/helpers/nextServer';
 
 // Start a Next.js server for testing the redirect.
-test('cs route loads directly without redirect', async ({ page }) => {
+test('all route loads directly without redirect', async ({ page }) => {
   const { server, port } = await startTestServer();
   const q = 'conversation=test-123';
   await page.goto(`http://localhost:${port}/dashboard/guest-experience/all?${q}`, {


### PR DESCRIPTION
## Summary
- rename the guest experience redirect E2E test to reflect the `/all` route

## Testing
- npx playwright test e2e/ge-cs-redirect.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68caf01deb50832abff31eaccd074c83