### PR TITLE
Sanitize app URL and update conversation deep links

### DIFF
--- a/lib/links.js
+++ b/lib/links.js
@@ -1,12 +1,10 @@
-export const trim = (s) => s.replace(/\/+$/, '')
+export const trim = (s) => s.replace(/\/+$/, '');
 // Remove ASCII control chars and stray whitespace to prevent broken links in emails
 const stripCtlAndTrim = (s) =>
-  String(s ?? '')
-    .replace(/[\u0000-\u001F\u007F]/g, '')
-    .trim()
+  String(s ?? '').replace(/[\u0000-\u001F\u007F]/g, '').trim();
 
 export const appUrl = () =>
-  trim(stripCtlAndTrim(process.env.APP_URL ?? 'https://app.boomnow.com'))
+  trim(stripCtlAndTrim(process.env.APP_URL ?? 'https://app.boomnow.com'));
 
 const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i
 
@@ -18,8 +16,9 @@ const normalizeBaseUrl = (input) => {
 export function makeConversationLink({ uuid, baseUrl }) {
   const base = normalizeBaseUrl(baseUrl)
   if (uuid && UUID_RE.test(String(uuid))) {
+    // Deep-link to the All page instead of CS
     return `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(
-      String(uuid).toLowerCase()
+      String(uuid).toLowerCase(),
     )}`
   }
   return null


### PR DESCRIPTION
## Summary
- terminate the trim and appUrl helpers with semicolons and keep the sanitisation helper in a compact form
- add an inline comment that clarifies the conversation deep link targets the Guest Experience “All” page

## Testing
- npm test *(fails: Playwright browsers not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caf5996b6c832aa383e1b244b5d802