### PR TITLE
Use shared appUrl helper when building alert links

### DIFF
--- a/apps/worker/mailer/alerts.tsx
+++ b/apps/worker/mailer/alerts.tsx
@@ -1,12 +1,13 @@
 import { metrics } from '../../../lib/metrics';
 import { buildUniversalConversationLink } from '../../../lib/alertLink';
+import { appUrl } from '../../shared/lib/links';
 
 export async function buildAlertEmail(
   event: { conversation_uuid?: string; legacyId?: number | string; slug?: string },
   deps?: { logger?: any; verify?: (url: string) => Promise<boolean> }
 ) {
   const logger = deps?.logger;
-  const base = (process.env.APP_URL || 'https://app.boomnow.com').replace(/\/+$/, '');
+  const base = appUrl();
   const built = await buildUniversalConversationLink(
     { uuid: event?.conversation_uuid, legacyId: event?.legacyId, slug: event?.slug },
     { baseUrl: base, verify: deps?.verify }


### PR DESCRIPTION
## Summary
- import the shared appUrl helper in the worker alert mailer
- rely on appUrl() for normalizing the base URL instead of duplicating logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb04e2d89c832abd118555094cecf8