### PR TITLE
Relax alert link verification for unauthenticated responses

### DIFF
--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -9,13 +9,17 @@ const UUID_RE =
 async function defaultVerify(url) {
   try {
     const res = await fetch(url, { method: 'GET', redirect: 'manual' });
+    // Accept a direct success
     if (res.status === 200) return true;
+    // Accept redirects to login or dashboard
     if (res.status >= 300 && res.status < 400) {
       const loc = res.headers.get('location') || '';
       if (loc.includes('/login') || loc.includes('/dashboard/guest-experience/all')) {
         return true;
       }
     }
+    // Treat common unauthenticated responses as valid
+    if ([401, 403, 406].includes(res.status)) return true;
     return false;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- accept 401/403/406 status codes in default alert link verification and document why

## Testing
- `npm test` *(fails: missing Playwright browsers in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0aa5c64c832a8650e77716203bf3