### PR TITLE
Use dashboard links for legacy alert fallbacks

### DIFF
--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -99,9 +99,17 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
       )}`;
     }
   } else if (fallbackRaw) {
-    url = `${base}${
-      /^[0-9]+$/.test(fallbackRaw) ? '/r/legacy/' : '/r/conversation/'
-    }${encodeURIComponent(fallbackRaw)}`;
+    // When we cannot resolve a UUID, fall back to a dashboard link instead of
+    // using legacy short-links, which do not work without JS enabled.
+    if (/^[0-9]+$/.test(fallbackRaw)) {
+      url = `${base}/dashboard/guest-experience/all?legacyId=${encodeURIComponent(
+        fallbackRaw
+      )}`;
+    } else {
+      url = `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(
+        fallbackRaw
+      )}`;
+    }
     kind = 'legacy';
   }
 

--- a/tests/alert-link.spec.ts
+++ b/tests/alert-link.spec.ts
@@ -93,7 +93,7 @@ test('buildUniversalConversationLink falls back to deep link when token mint fai
   expect(calls.length).toBeGreaterThanOrEqual(2);
 });
 
-test('buildUniversalConversationLink returns legacy shortlink when uuid unavailable', async () => {
+test('buildUniversalConversationLink returns dashboard link when uuid unavailable', async () => {
   process.env.LINK_SECRET = 'test-secret';
   delete process.env.RESOLVE_SECRET;
   delete process.env.RESOLVE_BASE_URL;
@@ -102,27 +102,37 @@ test('buildUniversalConversationLink returns legacy shortlink when uuid unavaila
     {
       baseUrl: BASE,
       verify: async (url) => {
-        expect(url).toBe(`${BASE}/r/legacy/456`);
+        expect(url).toBe(
+          `${BASE}/dashboard/guest-experience/all?legacyId=456`
+        );
         return true;
       },
     }
   );
-  expect(res).toEqual({ url: `${BASE}/r/legacy/456`, kind: 'legacy' });
+  expect(res).toEqual({
+    url: `${BASE}/dashboard/guest-experience/all?legacyId=456`,
+    kind: 'legacy',
+  });
 });
 
-test('buildUniversalConversationLink uses slug when numeric id missing', async () => {
+test('buildUniversalConversationLink uses slug query when numeric id missing', async () => {
   process.env.LINK_SECRET = 'test-secret';
   const res = await buildUniversalConversationLink(
     { slug: 'my-convo' },
     {
       baseUrl: BASE,
       verify: async (url) => {
-        expect(url).toBe(`${BASE}/r/conversation/my-convo`);
+        expect(url).toBe(
+          `${BASE}/dashboard/guest-experience/all?conversation=my-convo`
+        );
         return true;
       },
     }
   );
-  expect(res).toEqual({ url: `${BASE}/r/conversation/my-convo`, kind: 'legacy' });
+  expect(res).toEqual({
+    url: `${BASE}/dashboard/guest-experience/all?conversation=my-convo`,
+    kind: 'legacy',
+  });
 });
 
 test('buildUniversalConversationLink resolves identifiers via internal endpoint', async () => {

--- a/tests/conversation-link.spec.ts
+++ b/tests/conversation-link.spec.ts
@@ -140,13 +140,13 @@ test('mailer resolves legacyId via internal endpoint and emits token link', asyn
   expect(metricsArr).toContain('alerts.sent_with_uuid');
 });
 
-test('mailer falls back to legacy shortlink when uuid unavailable', async () => {
+test('mailer falls back to dashboard link when uuid unavailable', async () => {
   delete process.env.RESOLVE_SECRET;
   delete process.env.RESOLVE_BASE_URL;
   const emails: any[] = [];
   const metricsArr: string[] = [];
   const logger = { warn: () => {} };
-  const expected = `${BASE}/r/legacy/789`;
+  const expected = `${BASE}/dashboard/guest-experience/all?legacyId=789`;
   const verify = async (url: string) => {
     expect(url).toBe(expected);
     return true;
@@ -164,11 +164,13 @@ test('mailer falls back to legacy shortlink when uuid unavailable', async () => 
   expect(metricsArr).toContain('alerts.sent_with_legacy_shortlink');
 });
 
-test('mailer falls back to conversation slug when numeric id absent', async () => {
+test('mailer falls back to conversation slug query when numeric id absent', async () => {
   delete process.env.RESOLVE_SECRET;
   delete process.env.RESOLVE_BASE_URL;
   const slug = 'my-convo';
-  const expected = `${BASE}/r/conversation/${encodeURIComponent(slug)}`;
+  const expected = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(
+    slug
+  )}`;
   const emails: any[] = [];
   const metricsArr: string[] = [];
   const logger = { warn: () => {} };


### PR DESCRIPTION
## Summary
- change `buildUniversalConversationLink` to return dashboard guest-experience URLs when only legacy IDs or slugs are available
- update alert and mailer tests to expect the new dashboard fallback links

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb0b6d64d8832aa955d15f9a3bce16