### PR TITLE
feat: require uuid for universal conversation link

### DIFF
--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -85,6 +85,8 @@ async function resolveUuid(idOrSlug, base) {
 
 /**
  * Build a verified, user-safe conversation link.
+ * In strictUuid mode (default), we only return a link if a UUID is available.
+ * Otherwise we return null rather than a legacy/slug dashboard link.
  * Returns { url, kind } or null if we cannot produce a verified link.
  */
 export async function buildUniversalConversationLink(input = {}, opts = {}) {
@@ -100,6 +102,8 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
           }
         }
       : null;
+
+  const strictUuid = opts.strictUuid !== false;
 
   let uuid =
     typeof input?.uuid === 'string' && UUID_RE.test(input.uuid)
@@ -146,8 +150,12 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
       )}`;
     }
   } else if (fallbackRaw) {
-    // When we cannot resolve a UUID, fall back to a dashboard link instead of
-    // using legacy short-links, which do not work without JS enabled.
+    // UUID not available.
+    // In strict mode we refuse to produce a link to guarantee deep-link correctness.
+    if (strictUuid) {
+      return null;
+    }
+    // Non-strict mode: keep the old legacy dashboard links behavior.
     if (/^[0-9]+$/.test(fallbackRaw)) {
       url = `${base}/dashboard/guest-experience/all?legacyId=${encodeURIComponent(
         fallbackRaw


### PR DESCRIPTION
## Summary
- default universal conversation links to require a verified UUID before issuing a URL
- add strictUuid option and documentation explaining the new behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc6d4d50ec832aa92ee160b1b3642e