### PR TITLE
Enforce strict UUID for alert conversation links

### DIFF
--- a/check.mjs
+++ b/check.mjs
@@ -708,7 +708,7 @@ if (typeof globalThis.__CHECK_TEST__ === "undefined") {
     }
     // Build a **verified** link (token -> deep link -> hosted shortlink), else skip sending.
     const base = appUrl().replace(/\/+$/, "");
-    const built = await buildUniversalConversationLink({ uuid }, { baseUrl: base });
+    const built = await buildUniversalConversationLink({ uuid }, { baseUrl: base, strictUuid: true });
     if (!built) {
       console.log("Skip alert: unable to build a verified conversation link.");
       return;


### PR DESCRIPTION
## Summary
- require verified UUIDs when building alert conversation links in the SLA check script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc6ecdaf44832abd8832bafe4958db