### PR TITLE
Enforce strict UUID deep links in cron

### DIFF
--- a/cron.mjs
+++ b/cron.mjs
@@ -385,10 +385,11 @@ for (const { id } of toCheck) {
             ? { legacyId: lookupId }
             : { slug: String(lookupId) });
       const base = appUrl().replace(/\/+$/, "");
-      const built = await buildUniversalConversationLink(input, { baseUrl: base });
+      // Strict mode to guarantee deep-link correctness
+      const built = await buildUniversalConversationLink(input, { baseUrl: base, strictUuid: true });
       if (!built) {
-        logger?.warn?.({ convId, input }, 'skip alert: link did not pass preflight');
-        metrics?.increment?.('alerts.skipped_link_preflight');
+        logger?.warn?.({ convId, input }, 'skip alert: UUID not resolvable (strict mode)');
+        metrics?.increment?.('alerts.skipped_no_uuid');
         skipped.push(convId);
         skippedCount++;
         continue;


### PR DESCRIPTION
## Summary
- enforce strict UUID validation when building universal conversation links
- update logging and metrics to reflect strict UUID skip reason

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc6f95b0b0832a998159d39525a134