### PR TITLE
Enforce UUID requirement for alert link

### DIFF
--- a/apps/worker/mailer/alerts.tsx
+++ b/apps/worker/mailer/alerts.tsx
@@ -10,11 +10,11 @@ export async function buildAlertEmail(
   const base = appUrl();
   const built = await buildUniversalConversationLink(
     { uuid: event?.conversation_uuid, legacyId: event?.legacyId, slug: event?.slug },
-    { baseUrl: base, verify: deps?.verify }
+    { baseUrl: base, verify: deps?.verify, strictUuid: true }
   );
   if (!built) {
     logger?.warn?.({ event }, 'skip alert: unable to build verified link');
-    metrics.increment('alerts.skipped_link_preflight');
+    metrics.increment('alerts.skipped_no_uuid');
     return null;
   }
   metrics.increment(


### PR DESCRIPTION
## Summary
- require alert link generation to run with strict UUID verification
- update skip metric to reflect missing UUIDs specifically

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc707c4c4c832a94102e08b0e84142