### PR TITLE
Adjust alert link tests for strict UUID enforcement

### DIFF
--- a/tests/alert-link.spec.ts
+++ b/tests/alert-link.spec.ts
@@ -99,46 +99,24 @@ test('buildUniversalConversationLink falls back to deep link when token mint fai
   expect(calls.length).toBeGreaterThanOrEqual(2);
 });
 
-test('buildUniversalConversationLink returns dashboard link when uuid unavailable', async () => {
+test('buildUniversalConversationLink returns null when uuid unavailable (strict)', async () => {
+  delete process.env.LINK_SECRET;
+  const res = await buildUniversalConversationLink(
+    { slug: 'no-alias' },
+    { baseUrl: BASE, verify: async () => true, strictUuid: true }
+  );
+  expect(res).toBeNull();
+});
+
+test('buildUniversalConversationLink uses resolver(s) to obtain uuid; returns null if still unresolved', async () => {
   process.env.LINK_SECRET = 'test-secret';
   delete process.env.RESOLVE_SECRET;
   delete process.env.RESOLVE_BASE_URL;
   const res = await buildUniversalConversationLink(
     { legacyId: 456 },
-    {
-      baseUrl: BASE,
-      verify: async (url) => {
-        expect(url).toBe(
-          `${BASE}/dashboard/guest-experience/all?legacyId=456`
-        );
-        return true;
-      },
-    }
+    { baseUrl: BASE, verify: async () => true, strictUuid: true }
   );
-  expect(res).toEqual({
-    url: `${BASE}/dashboard/guest-experience/all?legacyId=456`,
-    kind: 'legacy',
-  });
-});
-
-test('buildUniversalConversationLink uses slug query when numeric id missing', async () => {
-  process.env.LINK_SECRET = 'test-secret';
-  const res = await buildUniversalConversationLink(
-    { slug: 'my-convo' },
-    {
-      baseUrl: BASE,
-      verify: async (url) => {
-        expect(url).toBe(
-          `${BASE}/dashboard/guest-experience/all?conversation=my-convo`
-        );
-        return true;
-      },
-    }
-  );
-  expect(res).toEqual({
-    url: `${BASE}/dashboard/guest-experience/all?conversation=my-convo`,
-    kind: 'legacy',
-  });
+  expect(res).toBeNull();
 });
 
 test('buildUniversalConversationLink resolves identifiers via internal endpoint', async () => {


### PR DESCRIPTION
## Summary
- update alert link strict-mode expectations to return null when no UUID can be resolved
- align alert mailer tests with strict UUID behavior and updated metrics when resolution fails

## Testing
- npm test *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc71c9f2c8832abb7986c374d4c260