### PR TITLE
Add shared conversation UUID resolver

### DIFF
--- a/apps/shared/lib/conversationUuid.js
+++ b/apps/shared/lib/conversationUuid.js
@@ -1,0 +1,17 @@
+import { tryResolveConversationUuid } from '../../server/lib/conversations.js';
+import { resolveViaInternalEndpoint } from '../../../lib/internalResolve.js';
+
+export async function resolveConversationUuid(idOrSlug, opts = {}) {
+  const raw = String(idOrSlug ?? '').trim();
+  if (!raw) return null;
+  try {
+    const maybe = await tryResolveConversationUuid(raw, opts);
+    if (maybe) return maybe.toLowerCase();
+  } catch {}
+  try {
+    const viaInternal = await resolveViaInternalEndpoint(raw);
+    return viaInternal ? viaInternal.toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/shared/lib/conversationUuid.ts
+++ b/apps/shared/lib/conversationUuid.ts
@@ -1,0 +1,27 @@
+import { tryResolveConversationUuid } from '../../server/lib/conversations.js';
+import { resolveViaInternalEndpoint } from '../../../lib/internalResolve.js';
+
+export type ResolveConversationOpts = {
+  inlineThread?: unknown;
+  fetchFirstMessage?: (idOrSlug: string) => Promise<unknown> | unknown;
+  skipRedirectProbe?: boolean;
+  onDebug?: (d: unknown) => void;
+};
+
+export async function resolveConversationUuid(
+  idOrSlug: string,
+  opts: ResolveConversationOpts = {}
+): Promise<string | null> {
+  const raw = String(idOrSlug ?? '').trim();
+  if (!raw) return null;
+  try {
+    const maybe = await tryResolveConversationUuid(raw, opts as any);
+    if (maybe) return maybe.toLowerCase();
+  } catch {}
+  try {
+    const viaInternal = await resolveViaInternalEndpoint(raw);
+    return viaInternal ? viaInternal.toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared helper that delegates to the server resolver and lowercases UUIDs
- expose the helper in both TS and JS variants for shared callers

## Testing
- npm test *(fails: Playwright browser binaries not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7fcfc9a4832abf34649f44a1a3aa