### PR TITLE
Add dynamic resolve conversation UUID loader

### DIFF
--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -37,6 +37,30 @@ async function getTryResolveConversationUuid() {
   return null;
 }
 
+let cachedResolveConversationUuid;
+let attemptedDynamicResolveLoad = false;
+async function getResolveConversationUuid() {
+  if (
+    typeof globalThis !== 'undefined' &&
+    typeof globalThis.resolveConversationUuid === 'function'
+  ) {
+    cachedResolveConversationUuid = globalThis.resolveConversationUuid;
+    return cachedResolveConversationUuid;
+  }
+  if (typeof cachedResolveConversationUuid === 'function') return cachedResolveConversationUuid;
+  if (attemptedDynamicResolveLoad) return null;
+  attemptedDynamicResolveLoad = true;
+  try {
+    const mod = await import('../apps/shared/lib/conversationUuid.js');
+    const fn = mod?.resolveConversationUuid;
+    if (typeof fn === 'function') {
+      cachedResolveConversationUuid = fn;
+      return fn;
+    }
+  } catch {}
+  return null;
+}
+
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 


### PR DESCRIPTION
## Summary
- add a cached loader that resolves conversation UUID support dynamically

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd40589830832a97ae07b5c33a9e16