### PR TITLE
Use resolveConversationUuid before fallback resolvers

### DIFF
--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -142,7 +142,18 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
       : '';
 
   if (!uuid && fallbackRaw) {
-    uuid = await resolveUuid(fallbackRaw, base);
+    const resolveConversationUuid = await getResolveConversationUuid();
+    if (typeof resolveConversationUuid === 'function') {
+      try {
+        const maybe = await resolveConversationUuid(fallbackRaw);
+        if (maybe && UUID_RE.test(maybe)) {
+          uuid = maybe.toLowerCase();
+        }
+      } catch {}
+    }
+    if (!uuid) {
+      uuid = await resolveUuid(fallbackRaw, base);
+    }
     if (!uuid) {
       const tryResolveConversationUuid = await getTryResolveConversationUuid();
       if (typeof tryResolveConversationUuid === 'function') {


### PR DESCRIPTION
## Summary
- call resolveConversationUuid before resolving via the internal endpoint or tryResolve fallbacks in buildUniversalConversationLink
- add coverage for the resolveConversationUuid hook and adjust existing tests to account for the new resolution order

## Testing
- npx playwright test tests/alert-link.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cd44b5ba98832a94f65d6f26459fed