### PR TITLE
Document conversation UUID namespace override and fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,7 @@ LIST_LIMIT_PARAM=limit
 LIST_OFFSET_PARAM=page
 PAGE_SIZE=30
 # CHECK_LIMIT=60  # (optional override)
+#
+# Optional: override deterministic UUID namespace (must be a UUID)
+# When unset, the namespace is derived from APP_URL and BOOM_ORG_ID.
+# CONV_UUID_NAMESPACE=00000000-0000-0000-0000-000000000000

--- a/docs/conversation-uuid-migration.md
+++ b/docs/conversation-uuid-migration.md
@@ -1,7 +1,13 @@
 # Conversation UUID Migration
 
-All alert-producing services must emit a `conversation_uuid` field containing the v4 UUID of the conversation.
-Numeric identifiers and slug-based lookups are no longer supported.
+All alert-producing services must emit a `conversation_uuid` field containing the UUID of the conversation.
+Numeric identifiers and slug-based lookups are no longer supported for **new** producers.
+
+**Operational fallback:**  
+If a legacy producer still emits only a numeric ID/slug and no UUID can be resolved from DB/aliases/probes,
+the system will **mint a deterministic UUIDv5** based on `APP_URL` + `BOOM_ORG_ID` and the identifier. This
+guarantees alerts can still carry a verified, deep-linkable UUID while we complete upstream migration.
+If/when a real UUID later becomes available for the same legacy ID, the alias table is updated to prefer the real one.
 
 Steps for producers:
 


### PR DESCRIPTION
## Summary
- document the optional CONV_UUID_NAMESPACE override in the sample environment file
- explain the deterministic UUIDv5 minting fallback for legacy producers in the migration guide

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd8b8b8604832a814bc729e7f84a2f