### PR TITLE
Document messages endpoint env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@ LIST_LIMIT_PARAM=limit
 LIST_OFFSET_PARAM=page
 PAGE_SIZE=30
 # CHECK_LIMIT=60  # (optional override)
+
+# The messages endpoint used by cron/check to fetch a conversation thread.
+# Use the {{conversationId}} placeholder; the scripts will inject the id/uuid.
+# This matches the UI deep link shape (?conversation=<uuid>).
+MESSAGES_URL=https://app.boomnow.com/api/guest-experience/messages?conversation={{conversationId}}
+MESSAGES_METHOD=GET
 #
 # Optional: override deterministic UUID namespace (must be a UUID)
 # When unset, the namespace is derived from APP_URL and BOOM_ORG_ID.


### PR DESCRIPTION
## Summary
- document the messages endpoint configuration in `.env.example`

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68cd9d7254a8832a881fde03c663ad0d