### PR TITLE
Add deterministic mint fallback when resolving conversation UUIDs

### DIFF
--- a/apps/shared/lib/conversationUuid.js
+++ b/apps/shared/lib/conversationUuid.js
@@ -1,5 +1,6 @@
 import { tryResolveConversationUuid } from '../../server/lib/conversations.js';
 import { resolveViaInternalEndpoint } from '../../../lib/internalResolve.js';
+import { mintUuidFromRaw } from './canonicalConversationUuid.js';
 
 export async function resolveConversationUuid(idOrSlug, opts = {}) {
   const raw = String(idOrSlug ?? '').trim();
@@ -11,6 +12,12 @@ export async function resolveConversationUuid(idOrSlug, opts = {}) {
   try {
     const viaInternal = await resolveViaInternalEndpoint(raw);
     return viaInternal ? viaInternal.toLowerCase() : null;
+  } catch {
+    // fall through to minting
+  }
+  try {
+    const minted = mintUuidFromRaw(raw);
+    return minted ? minted.toLowerCase() : null;
   } catch {
     return null;
   }

--- a/apps/shared/lib/conversationUuid.ts
+++ b/apps/shared/lib/conversationUuid.ts
@@ -1,5 +1,6 @@
 import { tryResolveConversationUuid } from '../../server/lib/conversations.js';
 import { resolveViaInternalEndpoint } from '../../../lib/internalResolve.js';
+import { mintUuidFromRaw } from './canonicalConversationUuid.js';
 
 export type ResolveConversationOpts = {
   inlineThread?: unknown;
@@ -21,6 +22,12 @@ export async function resolveConversationUuid(
   try {
     const viaInternal = await resolveViaInternalEndpoint(raw);
     return viaInternal ? viaInternal.toLowerCase() : null;
+  } catch {
+    // fall through to minting
+  }
+  try {
+    const minted = mintUuidFromRaw(raw);
+    return minted ? minted.toLowerCase() : null;
   } catch {
     return null;
   }

--- a/lib/internalResolve.js
+++ b/lib/internalResolve.js
@@ -6,18 +6,17 @@ const cleanBase = (u) =>
     .replace(/[\u0000-\u001F\u007F]/g, "")
     .trim()
     .replace(/\/+$/, "");
-const RESOLVE_BASE_URL = cleanBase(process.env.RESOLVE_BASE_URL || process.env.APP_URL || "https://app.boomnow.com");
-const RESOLVE_SECRET = process.env.RESOLVE_SECRET || "";
-
 export async function resolveViaInternalEndpoint(idOrSlug) {
-  if (!RESOLVE_SECRET) return null;
+  const secret = process.env.RESOLVE_SECRET || "";
+  if (!secret) return null;
+  const base = cleanBase(process.env.RESOLVE_BASE_URL || process.env.APP_URL || "https://app.boomnow.com");
   const ts = Date.now();
   const nonce = crypto.randomBytes(8).toString("hex");
   const id = String(idOrSlug);
   const params = new URLSearchParams({ id, ts: String(ts), nonce });
-  const sig = signResolve(id, ts, nonce, RESOLVE_SECRET);
+  const sig = signResolve(id, ts, nonce, secret);
   params.set("sig", sig);
-  const url = `${RESOLVE_BASE_URL}/api/internal/resolve-conversation?${params.toString()}`;
+  const url = `${base}/api/internal/resolve-conversation?${params.toString()}`;
   try {
     const res = await fetch(url, { method: "GET" });
     if (!res.ok) return null;


### PR DESCRIPTION
## Summary
- fall back to minting a deterministic UUID when direct and internal resolution attempts fail
- mirror the fallback logic in the TypeScript helper
't resolve
- read internal resolve configuration from the environment on each call so tests can override it

## Testing
- npm test *(fails: requires `npx playwright install` to download browsers in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbb88b064832a822b852710bbe37d