### PR TITLE
Add optional mint fallback control for conversation resolver

### DIFF
--- a/apps/shared/lib/conversationUuid.js
+++ b/apps/shared/lib/conversationUuid.js
@@ -11,14 +11,17 @@ export async function resolveConversationUuid(idOrSlug, opts = {}) {
   } catch {}
   try {
     const viaInternal = await resolveViaInternalEndpoint(raw);
-    return viaInternal ? viaInternal.toLowerCase() : null;
+    if (viaInternal) return viaInternal.toLowerCase();
   } catch {
     // fall through to minting
   }
-  try {
-    const minted = mintUuidFromRaw(raw);
-    return minted ? minted.toLowerCase() : null;
-  } catch {
-    return null;
+  if (opts.allowMintFallback !== false) {
+    try {
+      const minted = mintUuidFromRaw(raw);
+      return minted ? minted.toLowerCase() : null;
+    } catch {
+      return null;
+    }
   }
+  return null;
 }

--- a/apps/shared/lib/conversationUuid.ts
+++ b/apps/shared/lib/conversationUuid.ts
@@ -7,6 +7,7 @@ export type ResolveConversationOpts = {
   fetchFirstMessage?: (idOrSlug: string) => Promise<unknown> | unknown;
   skipRedirectProbe?: boolean;
   onDebug?: (d: unknown) => void;
+  allowMintFallback?: boolean;
 };
 
 export async function resolveConversationUuid(
@@ -21,14 +22,17 @@ export async function resolveConversationUuid(
   } catch {}
   try {
     const viaInternal = await resolveViaInternalEndpoint(raw);
-    return viaInternal ? viaInternal.toLowerCase() : null;
+    if (viaInternal) return viaInternal.toLowerCase();
   } catch {
     // fall through to minting
   }
-  try {
-    const minted = mintUuidFromRaw(raw);
-    return minted ? minted.toLowerCase() : null;
-  } catch {
-    return null;
+  if (opts.allowMintFallback !== false) {
+    try {
+      const minted = mintUuidFromRaw(raw);
+      return minted ? minted.toLowerCase() : null;
+    } catch {
+      return null;
+    }
   }
+  return null;
 }

--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -145,7 +145,9 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
     const resolveConversationUuid = await getResolveConversationUuid();
     if (typeof resolveConversationUuid === 'function') {
       try {
-        const maybe = await resolveConversationUuid(fallbackRaw);
+        const maybe = await resolveConversationUuid(fallbackRaw, {
+          allowMintFallback: false,
+        });
         if (maybe && UUID_RE.test(maybe)) {
           uuid = maybe.toLowerCase();
         }


### PR DESCRIPTION
## Summary
- update the shared conversation resolver to skip returning a minted UUID when `allowMintFallback` is set to false
- ensure universal link generation disables minting so strict UUID checks still short-circuit when resolution fails
- keep minted fallback enabled by default so direct callers continue to receive a deterministic UUID when other strategies fail

## Testing
- npx playwright test tests/alert-link.spec.ts
- npx playwright test tests/resolve-conversation.spec.ts
- npx playwright test tests/resolve-uuid.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68cdc694cf94832a8e0604af9cdc8612