### PR TITLE
Refine alert link verification

### DIFF
--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -66,17 +66,23 @@ const UUID_RE =
 
 async function defaultVerify(url) {
   try {
+    const u = new URL(url);
+    const isToken = /\/r\/t\/[^/]+$/.test(u.pathname);
     const res = await fetch(url, { method: 'GET', redirect: 'manual' });
-    // Accept a direct success
+
+    if (isToken) {
+      if (res.status >= 300 && res.status < 400) {
+        const loc = res.headers.get('location') || '';
+        return /\/dashboard\/guest-experience\/all\b/.test(loc) && /[?&]conversation=/.test(loc);
+      }
+      return false;
+    }
+
     if (res.status === 200) return true;
-    // Accept redirects to login or dashboard
     if (res.status >= 300 && res.status < 400) {
       const loc = res.headers.get('location') || '';
-      if (loc.includes('/login') || loc.includes('/dashboard/guest-experience/all')) {
-        return true;
-      }
+      return /\/login\b/.test(loc) || /\/dashboard\/guest-experience\/all\b/.test(loc);
     }
-    // Treat common unauthenticated responses as valid
     if ([401, 403, 406].includes(res.status)) return true;
     return false;
   } catch {


### PR DESCRIPTION
## Summary
- tighten default verification logic so token shortlinks only count when they redirect to the conversation deep link
- continue accepting deep-link responses that render directly, redirect to login/dashboard, or return common unauthenticated statuses

## Testing
- npm test *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdcce9f3a8832a83327d6b25e2b64e