### PR TITLE
Add fallback deep link test for verification failure

### DIFF
--- a/tests/alert-link.spec.ts
+++ b/tests/alert-link.spec.ts
@@ -253,8 +253,24 @@ test('buildUniversalConversationLink returns null when verification fails', asyn
     { uuid },
     {
       baseUrl: BASE,
-      verify: async () => false,
+      verify: async () => false, // both token and deep link fail -> null
     }
   );
   expect(res).toBeNull();
+});
+
+test('buildUniversalConversationLink falls back to deep link when token verification fails', async () => {
+  process.env.LINK_SECRET = 'test-secret';
+  const res = await buildUniversalConversationLink(
+    { uuid },
+    {
+      baseUrl: BASE,
+      verify: async (url) => {
+        // Simulate prod: /r/t/... does NOT redirect (fail), but deep link works.
+        return !/\/r\/t\//.test(url);
+      },
+    }
+  );
+  expect(res?.kind).toBe('uuid');
+  expect(res?.url).toBe(`${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`);
 });


### PR DESCRIPTION
## Summary
- clarify the verification failure test to note both probes fail
- add a regression test covering the deep link fallback when the token probe fails

## Testing
- npm test -- tests/alert-link.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cdcfbe68c8832abe3db6f9f293a433