### PR TITLE
Add minted metadata to resolve conversation API responses

### DIFF
--- a/app/api/internal/resolve-conversation/route.ts
+++ b/app/api/internal/resolve-conversation/route.ts
@@ -161,13 +161,13 @@ export async function GET(req: Request) {
     }
 
     return NextResponse.json(
-      { uuid: minted },
-      { status: 200, headers: { 'Cache-Control': 'no-store' } }
+      { uuid: minted, minted: true },
+      { status: 200, headers: { 'Cache-Control': 'no-store', 'X-Boom-Minted': '1' } }
     );
   }
 
   return NextResponse.json(
-    { uuid },
-    { status: 200, headers: { 'Cache-Control': 'no-store' } }
+    { uuid, minted: false },
+    { status: 200, headers: { 'Cache-Control': 'no-store', 'X-Boom-Minted': '0' } }
   );
 }


### PR DESCRIPTION
## Summary
- include a minted flag in resolve conversation API responses
- add X-Boom-Minted header to communicate minted state and cache headers remain no-store

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdd7064194832aaf947fa25fb298af