### PR TITLE
Clarify guest experience redirect comment

### DIFF
--- a/app/dashboard/guest-experience/all/page.tsx
+++ b/app/dashboard/guest-experience/all/page.tsx
@@ -14,7 +14,7 @@ export default function Page({ searchParams }: { searchParams: { conversation?: 
       ? searchParams.legacyId
       : undefined;
 
-  // If legacyId is present, or conversation is not a UUID, use the client-side resolver.
+  // Forward non-UUID/legacy to the client-side resolver to avoid redirect loops.
   if (legacyId) redirect(`/dashboard/guest-experience/cs?legacyId=${encodeURIComponent(legacyId)}`);
   if (conversation && !UUID_RE.test(conversation)) {
     redirect(`/dashboard/guest-experience/cs?conversation=${encodeURIComponent(conversation)}`);


### PR DESCRIPTION
## Summary
- clarify the guest experience redirect comment to note we forward non-UUID and legacy IDs to the client-side resolver

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdde5517c0832ab07daba3bcb40b19