### PR TITLE
Handle minted alert links safely

### DIFF
--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -107,10 +107,32 @@ async function resolveUuid(idOrSlug, base) {
     if (!res.ok) return null;
     const json = await res.json().catch(() => null);
     const u = json?.uuid;
-    const minted = Boolean(json?.minted);
-    return typeof u === 'string' && UUID_RE.test(u)
-      ? { uuid: u.toLowerCase(), minted }
-      : null;
+    return typeof u === 'string' && UUID_RE.test(u) ? u.toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveUuidDetailed(idOrSlug, base) {
+  const raw = String(idOrSlug || '').trim();
+  if (!raw) return null;
+  const secret = process.env.RESOLVE_SECRET || '';
+  const host = (process.env.RESOLVE_BASE_URL || base).replace(/\/+$/, '');
+  if (!secret) return null;
+  const ts = Date.now();
+  const nonce = crypto.randomBytes(8).toString('hex');
+  const sig = signResolve(raw, ts, nonce, secret);
+  const url = `${host}/api/internal/resolve-conversation?id=${encodeURIComponent(
+    raw
+  )}&ts=${ts}&nonce=${nonce}&sig=${sig}`;
+  try {
+    const res = await fetch(url, { method: 'GET' });
+    if (!res.ok) return null;
+    const json = await res.json().catch(() => null);
+    const u = json?.uuid;
+    const ok = typeof u === 'string' && UUID_RE.test(u);
+    if (!ok) return null;
+    return { uuid: u.toLowerCase(), minted: Boolean(json?.minted) };
   } catch {
     return null;
   }
@@ -142,7 +164,6 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
     typeof input?.uuid === 'string' && UUID_RE.test(input.uuid)
       ? input.uuid.toLowerCase()
       : null;
-  let minted = false;
 
   const fallbackRaw =
     input?.legacyId != null
@@ -164,10 +185,9 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
       } catch {}
     }
     if (!uuid) {
-      const detailed = await resolveUuid(fallbackRaw, base);
-      if (detailed?.uuid) {
-        uuid = detailed.uuid;
-        minted = Boolean(detailed.minted);
+      const resolved = await resolveUuid(fallbackRaw, base);
+      if (resolved) {
+        uuid = resolved;
       }
     }
     if (!uuid) {
@@ -190,18 +210,23 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
   let alreadyVerified = false;
 
   if (uuid) {
-    if (strictUuid && minted && fallbackRaw) {
-      if (/^[0-9]+$/.test(fallbackRaw)) {
-        url = `${base}/dashboard/guest-experience/all?legacyId=${encodeURIComponent(
-          fallbackRaw
-        )}`;
-      } else {
-        url = `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(
-          fallbackRaw
-        )}`;
+    if (fallbackRaw) {
+      const detail = await resolveUuidDetailed(fallbackRaw, base).catch(() => null);
+      if (detail?.minted) {
+        kind = 'legacy';
+        if (/^[0-9]+$/.test(fallbackRaw)) {
+          url = `${base}/dashboard/guest-experience/all?legacyId=${encodeURIComponent(
+            fallbackRaw
+          )}`;
+        } else {
+          url = `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(
+            fallbackRaw
+          )}`;
+        }
       }
-      kind = 'legacy';
-    } else {
+    }
+
+    if (!url) {
       // Prefer token link; if mint fails OR token verification fails, degrade to deep link.
       let candidate = null;
       try {

--- a/tests/alert-link.spec.ts
+++ b/tests/alert-link.spec.ts
@@ -283,7 +283,7 @@ test('buildUniversalConversationLink falls back to internal resolver when resolv
     }
   );
   expect(res?.kind).toBe('uuid');
-  expect(fetchCalls).toHaveLength(1);
+  expect(fetchCalls).toHaveLength(2);
   expect(resolveCalls).toEqual(['needs-fallback']);
   expect(tryResolveCalls).toEqual([
     {
@@ -321,7 +321,7 @@ test('buildUniversalConversationLink falls back to deep link when token verifica
   expect(res?.url).toBe(`${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`);
 });
 
-test('buildUniversalConversationLink prefers token link when minted uuid but strict mode disabled', async () => {
+test('buildUniversalConversationLink uses legacy link for minted identifiers even when strict mode disabled', async () => {
   process.env.LINK_SECRET = 'test-secret';
   process.env.RESOLVE_SECRET = 'resolve';
   process.env.RESOLVE_BASE_URL = 'https://resolve.test';
@@ -338,7 +338,7 @@ test('buildUniversalConversationLink prefers token link when minted uuid but str
       },
     }
   );
-  expect(res?.kind).toBe('uuid');
-  expect(res?.url?.startsWith(`${BASE}/r/t/`)).toBe(true);
-  expect(seen[0]?.startsWith(`${BASE}/r/t/`)).toBe(true);
+  const legacy = `${BASE}/dashboard/guest-experience/all?legacyId=654`;
+  expect(res).toEqual({ kind: 'legacy', url: legacy });
+  expect(seen).toEqual([legacy]);
 });


### PR DESCRIPTION
## Summary
- add a detailed resolver helper so minted status can be checked separately from uuid resolution
- use the detailed resolver to force legacy-safe links when the identifier resolves to a minted conversation
- refresh alert link tests to cover the new minted behaviour and extra resolver probe

## Testing
- npx playwright test tests/alert-link.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cdeba21b64832a8fea0d5ba8632891