### PR TITLE
Ensure alert links include legacy identifiers

### DIFF
--- a/check.mjs
+++ b/check.mjs
@@ -703,9 +703,14 @@ if (typeof globalThis.__CHECK_TEST__ === "undefined") {
       metrics.increment('alerts.skipped_producer_violation');
       return;
     }
-    // Build a **verified** link (token -> deep link -> hosted shortlink), else skip sending.
+    // Build a **verified** link. If the uuid came from a minted fallback,
+    // the builder will degrade to a legacy-safe dashboard link.
     const base = appUrl().replace(/\/+$/, "");
-    const built = await buildUniversalConversationLink({ uuid }, { baseUrl: base, strictUuid: true });
+    const inputForBuilder =
+      /^\d+$/.test(String(convId))
+        ? { uuid, legacyId: String(convId) }
+        : { uuid, slug: String(convId) };
+    const built = await buildUniversalConversationLink(inputForBuilder, { baseUrl: base, strictUuid: true });
     if (!built) {
       console.log("Skip alert: unable to build a verified conversation link.");
       return;

--- a/cron.mjs
+++ b/cron.mjs
@@ -419,9 +419,11 @@ for (const { id } of toCheck) {
       });
 
       const input = uuid
-        ? { uuid }
+        ? (/^[0-9]+$/.test(String(lookupId))
+            ? { uuid, legacyId: String(lookupId) }
+            : { uuid, slug: String(lookupId) })
         : (/^[0-9]+$/.test(String(lookupId))
-            ? { legacyId: lookupId }
+            ? { legacyId: String(lookupId) }
             : { slug: String(lookupId) });
       const base = appUrl().replace(/\/+$/, "");
       // Strict mode to guarantee deep-link correctness


### PR DESCRIPTION
## Summary
- include legacy IDs or slugs when building verified conversation links in the SLA check flow
- propagate the same identifier metadata in the cron alert builder so fallback links work with minted UUIDs

## Testing
- `npm test` *(fails: Playwright browsers missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf3f2f7d0832ab2c479030bfd70cf