### PR TITLE
Ensure internal resolver uses current resolve config

### DIFF
--- a/lib/internalResolve.js
+++ b/lib/internalResolve.js
@@ -8,22 +8,29 @@ function cleanBase(u) {
     .replace(/\/+$/, "");
 }
 
-const RESOLVE_SECRET = process.env.RESOLVE_SECRET || "";
-const RESOLVE_BASE_URL = cleanBase(
-  process.env.RESOLVE_BASE_URL ||
-    process.env.APP_URL ||
-    "https://app.boomnow.com"
-);
+function getResolveSecret() {
+  return process.env.RESOLVE_SECRET || "";
+}
+
+function getResolveBaseUrl() {
+  return cleanBase(
+    process.env.RESOLVE_BASE_URL ||
+      process.env.APP_URL ||
+      "https://app.boomnow.com"
+  );
+}
 
 export async function resolveViaInternalEndpoint(idOrSlug) {
-  if (!RESOLVE_SECRET) return null;
+  const secret = getResolveSecret();
+  if (!secret) return null;
   const ts = Date.now();
   const nonce = crypto.randomBytes(8).toString("hex");
   const id = String(idOrSlug);
   const params = new URLSearchParams({ id, ts: String(ts), nonce });
-  const sig = signResolve(id, ts, nonce, RESOLVE_SECRET);
+  const sig = signResolve(id, ts, nonce, secret);
   params.set("sig", sig);
-  const url = `${RESOLVE_BASE_URL}/api/internal/resolve-conversation?${params.toString()}`;
+  const baseUrl = getResolveBaseUrl();
+  const url = `${baseUrl}/api/internal/resolve-conversation?${params.toString()}`;
   try {
     const res = await fetch(url, { method: "GET" });
     if (!res.ok) return null;
@@ -36,14 +43,16 @@ export async function resolveViaInternalEndpoint(idOrSlug) {
 
 // Detailed variant – returns { uuid, minted } so callers can avoid deep-linking to minted UUIDs.
 export async function resolveViaInternalEndpointWithDetails(idOrSlug) {
-  if (!RESOLVE_SECRET) return null;
+  const secret = getResolveSecret();
+  if (!secret) return null;
   const ts = Date.now();
   const nonce = crypto.randomBytes(8).toString("hex");
   const id = String(idOrSlug);
   const params = new URLSearchParams({ id, ts: String(ts), nonce });
-  const sig = signResolve(id, ts, nonce, RESOLVE_SECRET);
+  const sig = signResolve(id, ts, nonce, secret);
   params.set("sig", sig);
-  const url = `${RESOLVE_BASE_URL}/api/internal/resolve-conversation?${params.toString()}`;
+  const baseUrl = getResolveBaseUrl();
+  const url = `${baseUrl}/api/internal/resolve-conversation?${params.toString()}`;
   try {
     const res = await fetch(url, { method: "GET" });
     if (!res.ok) return null;


### PR DESCRIPTION
## Summary
- expose the new minted flag in internal resolver responses without caching stale environment configuration
- refresh resolve secret and base URL lookups on each call so runtime env changes continue to work in tests and cron scripts

## Testing
- npm test *(fails: Playwright browsers unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf52ef0bc832a92319cbc105fdbca