### PR TITLE
Prevent minting unresolvable UUIDs

### DIFF
--- a/app/api/internal/resolve-conversation/route.ts
+++ b/app/api/internal/resolve-conversation/route.ts
@@ -128,6 +128,10 @@ export async function GET(req: Request) {
 
   const uuid = await resolveAny(id);
   if (!uuid) {
+    // If caller passed a UUID and we couldn't find it, do NOT mint – it's not real.
+    if (UUID_RE.test(id)) {
+      return NextResponse.json({ error: 'not_found' }, { status: 404 });
+    }
     const minted = mintUuidFromRaw(id);
     if (!minted) {
       return NextResponse.json({ error: 'not_found' }, { status: 404 });


### PR DESCRIPTION
## Summary
- avoid minting a new conversation UUID when the requested id already looks like a UUID but cannot be resolved

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdfbc487f8832a96581b6ed1230077