### PR TITLE
Route minted legacy links through resolver endpoints

### DIFF
--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -213,16 +213,13 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
     if (fallbackRaw) {
       const detail = await resolveUuidDetailed(fallbackRaw, base).catch(() => null);
       if (detail?.minted) {
-        kind = 'legacy';
+        // ULC-v2: never deep-link with a non-UUID query. Route via resolvers.
         if (/^[0-9]+$/.test(fallbackRaw)) {
-          url = `${base}/dashboard/guest-experience/all?legacyId=${encodeURIComponent(
-            fallbackRaw
-          )}`;
+          url = `${base}/r/legacy/${encodeURIComponent(fallbackRaw)}`;
         } else {
-          url = `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(
-            fallbackRaw
-          )}`;
+          url = `${base}/r/conversation/${encodeURIComponent(fallbackRaw)}`;
         }
+        kind = 'resolver';
       }
     }
 


### PR DESCRIPTION
## Summary
- route minted fallback links through resolver endpoints instead of dashboard query params
- update alert link tests to expect resolver URLs and kinds

## Testing
- npm test *(fails: Playwright browsers not installed in container)*
- npx playwright test tests/alert-link.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68ceab8f96b0832a826f59514a577a33