### PR TITLE
Redirect unresolved conversation links to guest experience all view

### DIFF
--- a/app/r/conversation/[id]/route.ts
+++ b/app/r/conversation/[id]/route.ts
@@ -13,6 +13,6 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
   const base = appUrlFromRequest(req);
   const to = uuid
     ? conversationDeepLinkFromUuid(uuid, { baseUrl: base })
-    : `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(raw)}`;
+    : `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(raw)}`;
   return NextResponse.redirect(to, 302);
 }


### PR DESCRIPTION
## Summary
- update the fallback redirect to point to the guest experience "all" dashboard view when a conversation UUID cannot be resolved

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ceacb0a4c4832a8c2166a11ed7218b