### PR TITLE
Add canonical conversation resolve API

### DIFF
--- a/app/api/resolve/any/route.ts
+++ b/app/api/resolve/any/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server.js';
+import { tryResolveConversationUuid } from '../../../../apps/server/lib/conversations.js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const raw = (searchParams.get('id') || '').trim();
+  if (!raw) {
+    return NextResponse.json({ error: 'bad_request' }, { status: 400 });
+  }
+  try {
+    // No minting here; this endpoint is purely for canonical resolution.
+    const uuid = await tryResolveConversationUuid(raw, { skipRedirectProbe: false });
+    if (uuid) {
+      return NextResponse.json(
+        { uuid: String(uuid).toLowerCase() },
+        { status: 200, headers: { 'Cache-Control': 'no-store' } }
+      );
+    }
+  } catch {}
+  return NextResponse.json({ error: 'not_found' }, { status: 404 });
+}


### PR DESCRIPTION
## Summary
- add a force-dynamic API route for resolving arbitrary conversation identifiers
- reuse the existing tryResolveConversationUuid helper and normalize the UUID response

## Testing
- npm test *(fails: missing Playwright browsers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cead31536c832abe38a329c2789bff