### PR TITLE
Avoid reminting conversation UUID inputs

### DIFF
--- a/apps/shared/lib/conversationUuid.js
+++ b/apps/shared/lib/conversationUuid.js
@@ -1,6 +1,6 @@
 import { tryResolveConversationUuid } from '../../server/lib/conversations.js';
 import { resolveViaInternalEndpoint } from '../../../lib/internalResolve.js';
-import { mintUuidFromRaw } from './canonicalConversationUuid.js';
+import { mintUuidFromRaw, isUuid } from './canonicalConversationUuid.js';
 
 export async function resolveConversationUuid(idOrSlug, opts = {}) {
   const raw = String(idOrSlug ?? '').trim();
@@ -15,7 +15,8 @@ export async function resolveConversationUuid(idOrSlug, opts = {}) {
   } catch {
     // fall through to minting
   }
-  if (opts.allowMintFallback !== false) {
+  // ULC-v2: do not mint when the raw value is already a UUID; that produces broken links.
+  if (opts.allowMintFallback !== false && !isUuid(raw)) {
     try {
       const minted = mintUuidFromRaw(raw);
       return minted ? minted.toLowerCase() : null;

--- a/apps/shared/lib/conversationUuid.ts
+++ b/apps/shared/lib/conversationUuid.ts
@@ -1,6 +1,6 @@
 import { tryResolveConversationUuid } from '../../server/lib/conversations.js';
 import { resolveViaInternalEndpoint } from '../../../lib/internalResolve.js';
-import { mintUuidFromRaw } from './canonicalConversationUuid.js';
+import { mintUuidFromRaw, isUuid } from './canonicalConversationUuid.js';
 
 export type ResolveConversationOpts = {
   inlineThread?: unknown;
@@ -26,7 +26,8 @@ export async function resolveConversationUuid(
   } catch {
     // fall through to minting
   }
-  if (opts.allowMintFallback !== false) {
+  // ULC-v2: do not mint when the raw value is already a UUID.
+  if (opts.allowMintFallback !== false && !isUuid(raw)) {
     try {
       const minted = mintUuidFromRaw(raw);
       return minted ? minted.toLowerCase() : null;


### PR DESCRIPTION
## Summary
- avoid minting a new UUID when the provided slug is already a UUID
- reuse the shared `isUuid` helper in both JS and TS conversation resolvers to skip reminting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ceafed24e4832abfd821649571c14f