### PR TITLE
Accept newer UUID versions in conversation deep links

### DIFF
--- a/app/api/internal/resolve-conversation/route.ts
+++ b/app/api/internal/resolve-conversation/route.ts
@@ -5,7 +5,7 @@ import { mintUuidFromRaw } from '../../../../apps/shared/lib/canonicalConversati
 
 const RESOLVE_SECRET = process.env.RESOLVE_SECRET || '';
 const MAX_SKEW_MS = 2 * 60 * 1000; // 2 minutes
-const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
 
 function normalizeUuid(uuid: string | null | undefined) {
   return uuid && UUID_RE.test(uuid) ? uuid.toLowerCase() : null;

--- a/app/api/resolve/conversation/route.ts
+++ b/app/api/resolve/conversation/route.ts
@@ -2,7 +2,7 @@ import { prisma } from '../../../../lib/db';
 import { redis } from '../../../../lib/redis';
 import { metrics } from '../../../../lib/metrics';
 
-const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
 
 async function dbLookup(legacyId: number) {
   const alias = await prisma.conversation_aliases.findUnique({ where: { legacy_id: legacyId } });

--- a/app/dashboard/guest-experience/all/page.tsx
+++ b/app/dashboard/guest-experience/all/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'next/navigation';
 import GuestExperience from './GuestExperience';
 
 const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export default function Page({ searchParams }: { searchParams: { conversation?: string; legacyId?: string } }) {
   const conversation =

--- a/app/dashboard/guest-experience/cs/page.tsx
+++ b/app/dashboard/guest-experience/cs/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 
-const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
 
 export default function CsPage() {
   const params = useSearchParams();

--- a/apps/server/lib/conversations.js
+++ b/apps/server/lib/conversations.js
@@ -2,7 +2,7 @@ import { isUuid } from '../../shared/lib/uuid.js';
 import { prisma } from '../../../lib/db.js';
 
 const UUID_RE =
-  /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
 
 const appUrl = () => (process.env.APP_URL ?? 'https://app.boomnow.com').replace(/\/+$/,'');
 

--- a/apps/shared/lib/canonicalConversationUuid.js
+++ b/apps/shared/lib/canonicalConversationUuid.js
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const DNS_NS  = '6ba7b810-9dad-11d1-80b4-00c04fd430c8'; // RFC 4122 DNS namespace
 
 function parseUuid(u) {

--- a/apps/shared/lib/canonicalConversationUuid.ts
+++ b/apps/shared/lib/canonicalConversationUuid.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const DNS_NS  = '6ba7b810-9dad-11d1-80b4-00c04fd430c8'; // RFC 4122 DNS namespace
 
 function parseUuid(u: string): Uint8Array {

--- a/apps/shared/lib/links.ts
+++ b/apps/shared/lib/links.ts
@@ -4,7 +4,7 @@ const stripCtlAndTrim = (s: string) =>
 export const appUrl = () =>
   trim(stripCtlAndTrim(process.env.APP_URL ?? 'https://app.boomnow.com'));
 
-const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i
 
 type ConversationLinkArgs = { uuid?: string | null; baseUrl?: string | URL }
 

--- a/apps/shared/lib/uuid.js
+++ b/apps/shared/lib/uuid.js
@@ -1,3 +1,3 @@
 export function isUuid(v) {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v ?? '');
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v ?? '');
 }

--- a/apps/shared/lib/uuid.ts
+++ b/apps/shared/lib/uuid.ts
@@ -1,3 +1,3 @@
 export function isUuid(v: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v ?? '');
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v ?? '');
 }

--- a/check.mjs
+++ b/check.mjs
@@ -135,7 +135,7 @@ function firstUrlLike(s) {
   if (!m) return "";
   return m[0].replace(/[>),.;!'"`]+$/, "");
 }
-const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
 const SLUG_RE = /^[A-Za-z0-9_-]{8,64}$/;
 function extractConversationId(input) {
   const s = (input || "").trim();

--- a/cron.mjs
+++ b/cron.mjs
@@ -14,7 +14,7 @@ const metrics = { increment: () => {} };
 // Assumes ESM. Node 18+ provides global fetch. If you're on older Node, ensure node-fetch is installed & imported.
 
 // Accept a canonical UUID (v1–v5)
-const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
 
 // Build a safe user-facing link: prefer deep link with UUID, else dashboard filters.
 export function buildSafeDeepLink(lookupId, uuid) {

--- a/e2e/deeplink-redirect.spec.ts
+++ b/e2e/deeplink-redirect.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import { startTestServer, stopTestServer } from '../tests/helpers/nextServer';
 import { makeLinkToken } from '../apps/shared/lib/linkToken';
 
-const uuid = '123e4567-e89b-12d3-a456-426614174000';
+const uuid = '01890b14-b4cd-7eef-b13e-bb8c083bad60';
 
 test.use({ ignoreHTTPSErrors: true });
 

--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -62,7 +62,7 @@ async function getResolveConversationUuid() {
 }
 
 const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 async function defaultVerify(url) {
   try {

--- a/lib/linkToken.js
+++ b/lib/linkToken.js
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function secret() {
   const s = process.env.LINK_SECRET;

--- a/lib/links.js
+++ b/lib/links.js
@@ -6,7 +6,7 @@ const stripCtlAndTrim = (s) =>
 export const appUrl = () =>
   trim(stripCtlAndTrim(process.env.APP_URL ?? 'https://app.boomnow.com'));
 
-const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i
 
 const normalizeBaseUrl = (input) => {
   const raw = input ? String(input) : appUrl()

--- a/tests/conversation-link.spec.ts
+++ b/tests/conversation-link.spec.ts
@@ -5,7 +5,7 @@ import { buildAlertEmail } from '../apps/worker/mailer/alerts';
 import { metrics } from '../lib/metrics';
 
 const BASE = process.env.APP_URL ?? 'https://app.boomnow.com';
-const uuid = '123e4567-e89b-12d3-a456-426614174000';
+const uuid = '01890b14-b4cd-7eef-b13e-bb8c083bad60';
 const ORIGINAL_LINK_SECRET = process.env.LINK_SECRET;
 const ORIGINAL_RESOLVE_SECRET = process.env.RESOLVE_SECRET;
 const ORIGINAL_RESOLVE_BASE_URL = process.env.RESOLVE_BASE_URL;
@@ -47,7 +47,7 @@ test('makeConversationLink builds ?conversation when uuid provided', () => {
 test('makeConversationLink accepts baseUrl override', () => {
   expect(
     makeConversationLink({ uuid, baseUrl: 'http://localhost:4321' })
-  ).toBe('http://localhost:4321/dashboard/guest-experience/all?conversation=123e4567-e89b-12d3-a456-426614174000');
+  ).toBe(`http://localhost:4321/dashboard/guest-experience/all?conversation=${uuid}`);
 });
 
 test('makeConversationLink returns null when uuid missing', () => {

--- a/tests/helpers/nextServer.ts
+++ b/tests/helpers/nextServer.ts
@@ -7,7 +7,7 @@ type StartedServer = { server: http.Server; port: number };
 
 const previousAppUrl = new WeakMap<http.Server, string | undefined>();
 
-const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
 
 const HTML = `<!DOCTYPE html>
 <html>

--- a/tests/uuid.spec.ts
+++ b/tests/uuid.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+import { isUuid } from '../apps/shared/lib/uuid';
+
+test('isUuid accepts UUIDv7 strings', () => {
+  const v7 = '01890b14-b4cd-7eef-b13e-bb8c083bad60';
+  expect(isUuid(v7)).toBe(true);
+});
+
+test('isUuid rejects malformed values', () => {
+  expect(isUuid('not-a-uuid')).toBe(false);
+  expect(isUuid('12345678-1234-1234-1234-1234567890')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- relax the UUID validation regex across link builders, middleware, and resolvers so conversation deep links accept newer versions (e.g. UUIDv7)
- update conversation link tests and e2e deep-link coverage to exercise UUIDv7 values and add a unit test for isUuid

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceca8bb2b4832ab02362d98c479a6b