### PR TITLE
Handle minted UUID fallbacks in universal conversation links

### DIFF
--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import { appUrl } from './links.js';
 import { makeLinkToken } from './linkToken.js';
 import { signResolve } from '../apps/shared/lib/resolveSign.js';
+import { mintUuidFromRaw } from '../apps/shared/lib/canonicalConversationUuid.js';
 
 let cachedTryResolveConversationUuid =
   typeof globalThis !== 'undefined' ? globalThis.tryResolveConversationUuid : undefined;
@@ -210,10 +211,25 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
   let alreadyVerified = false;
 
   if (uuid) {
+    let mintedFallback = false;
     if (fallbackRaw) {
       const detail = await resolveUuidDetailed(fallbackRaw, base).catch(() => null);
+      if (detail?.uuid && UUID_RE.test(detail.uuid)) {
+        uuid = detail.uuid.toLowerCase();
+      }
       if (detail?.minted) {
-        // ULC-v2: never emit non-UUID query links; use resolver shortlinks.
+        mintedFallback = true;
+      } else if (!UUID_RE.test(fallbackRaw)) {
+        try {
+          const mintedGuess = mintUuidFromRaw(fallbackRaw);
+          if (mintedGuess && mintedGuess.toLowerCase() === uuid) {
+            mintedFallback = true;
+          }
+        } catch {
+          // ignore minting failures; fall back to token/deep-link path below
+        }
+      }
+      if (mintedFallback) {
         kind = 'resolver';
         url = /^[0-9]+$/.test(fallbackRaw)
           ? `${base}/r/legacy/${encodeURIComponent(fallbackRaw)}`


### PR DESCRIPTION
## Summary
- detect minted UUID fallbacks in buildUniversalConversationLink and emit resolver shortlinks instead of unusable conversation query links
- keep canonical UUIDs when resolver details are present while still honoring resolver-provided metadata
- cover minted fallback detection without resolver details with a dedicated unit test

## Testing
- npm test *(fails: Playwright browsers missing in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceec6e0d44832aaae6391a47fcae22