### PR TITLE
Refactor alert conversation link pipeline

### DIFF
--- a/apps/worker/mailer/alerts.tsx
+++ b/apps/worker/mailer/alerts.tsx
@@ -1,5 +1,5 @@
 import { metrics } from '../../../lib/metrics';
-import { buildUniversalConversationLink } from '../../../lib/alertLink';
+import { buildAlertConversationLink } from '../../../lib/conversationLink.js';
 import { appUrl } from '../../shared/lib/links';
 
 export async function buildAlertEmail(
@@ -8,10 +8,11 @@ export async function buildAlertEmail(
 ) {
   const logger = deps?.logger;
   const base = appUrl();
-  const built = await buildUniversalConversationLink(
-    { uuid: event?.conversation_uuid, legacyId: event?.legacyId, slug: event?.slug },
-    { baseUrl: base, verify: deps?.verify, strictUuid: true }
-  );
+  const built = await buildAlertConversationLink(event, {
+    baseUrl: base,
+    verify: deps?.verify,
+    strictUuid: true,
+  });
   if (!built) {
     logger?.warn?.({ event }, 'skip alert: unable to build verified link');
     metrics.increment('alerts.skipped_no_uuid');

--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -1,8 +1,7 @@
-import crypto from 'node:crypto';
 import { appUrl } from './links.js';
 import { makeLinkToken } from './linkToken.js';
-import { signResolve } from '../apps/shared/lib/resolveSign.js';
 import { mintUuidFromRaw } from '../apps/shared/lib/canonicalConversationUuid.js';
+import { resolveViaInternalEndpointWithDetails } from './internalResolve.js';
 
 let cachedTryResolveConversationUuid =
   typeof globalThis !== 'undefined' ? globalThis.tryResolveConversationUuid : undefined;
@@ -91,54 +90,6 @@ async function defaultVerify(url) {
   }
 }
 
-async function resolveUuid(idOrSlug, base) {
-  const raw = String(idOrSlug || '').trim();
-  if (!raw) return null;
-  const secret = process.env.RESOLVE_SECRET || '';
-  const host = (process.env.RESOLVE_BASE_URL || base).replace(/\/+$/, '');
-  if (!secret) return null;
-  const ts = Date.now();
-  const nonce = crypto.randomBytes(8).toString('hex');
-  const sig = signResolve(raw, ts, nonce, secret);
-  const url = `${host}/api/internal/resolve-conversation?id=${encodeURIComponent(
-    raw
-  )}&ts=${ts}&nonce=${nonce}&sig=${sig}`;
-  try {
-    const res = await fetch(url, { method: 'GET' });
-    if (!res.ok) return null;
-    const json = await res.json().catch(() => null);
-    const u = json?.uuid;
-    return typeof u === 'string' && UUID_RE.test(u) ? u.toLowerCase() : null;
-  } catch {
-    return null;
-  }
-}
-
-async function resolveUuidDetailed(idOrSlug, base) {
-  const raw = String(idOrSlug || '').trim();
-  if (!raw) return null;
-  const secret = process.env.RESOLVE_SECRET || '';
-  const host = (process.env.RESOLVE_BASE_URL || base).replace(/\/+$/, '');
-  if (!secret) return null;
-  const ts = Date.now();
-  const nonce = crypto.randomBytes(8).toString('hex');
-  const sig = signResolve(raw, ts, nonce, secret);
-  const url = `${host}/api/internal/resolve-conversation?id=${encodeURIComponent(
-    raw
-  )}&ts=${ts}&nonce=${nonce}&sig=${sig}`;
-  try {
-    const res = await fetch(url, { method: 'GET' });
-    if (!res.ok) return null;
-    const json = await res.json().catch(() => null);
-    const u = json?.uuid;
-    const ok = typeof u === 'string' && UUID_RE.test(u);
-    if (!ok) return null;
-    return { uuid: u.toLowerCase(), minted: Boolean(json?.minted) };
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Build a verified, user-safe conversation link.
  * In strictUuid mode (default), we only return a link if a UUID is available.
@@ -173,6 +124,8 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
       ? input.slug.trim()
       : '';
 
+  let resolverDetail = null;
+
   if (!uuid && fallbackRaw) {
     const resolveConversationUuid = await getResolveConversationUuid();
     if (typeof resolveConversationUuid === 'function') {
@@ -186,9 +139,9 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
       } catch {}
     }
     if (!uuid) {
-      const resolved = await resolveUuid(fallbackRaw, base);
-      if (resolved) {
-        uuid = resolved;
+      resolverDetail = await resolveViaInternalEndpointWithDetails(fallbackRaw).catch(() => null);
+      if (resolverDetail?.uuid && UUID_RE.test(resolverDetail.uuid)) {
+        uuid = resolverDetail.uuid.toLowerCase();
       }
     }
     if (!uuid) {
@@ -213,11 +166,15 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
   if (uuid) {
     let mintedFallback = false;
     if (fallbackRaw) {
-      const detail = await resolveUuidDetailed(fallbackRaw, base).catch(() => null);
-      if (detail?.uuid && UUID_RE.test(detail.uuid)) {
-        uuid = detail.uuid.toLowerCase();
+      if (!resolverDetail) {
+        resolverDetail = await resolveViaInternalEndpointWithDetails(fallbackRaw).catch(
+          () => null
+        );
       }
-      if (detail?.minted) {
+      if (resolverDetail?.uuid && UUID_RE.test(resolverDetail.uuid)) {
+        uuid = resolverDetail.uuid.toLowerCase();
+      }
+      if (resolverDetail?.minted) {
         mintedFallback = true;
       } else if (!UUID_RE.test(fallbackRaw)) {
         try {

--- a/lib/conversationLink.js
+++ b/lib/conversationLink.js
@@ -1,0 +1,194 @@
+import { buildUniversalConversationLink } from './alertLink.js';
+import { conversationIdDisplay } from './links.js';
+
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+const LEGACY_RE = /^[0-9]+$/;
+
+const UUID_KEYS = [
+  'conversation_uuid',
+  'conversationUuid',
+  'conversationUUID',
+  'uuid',
+  'conversationId',
+  'conversation_id',
+  'conversationID',
+  'conversation',
+  'public_id',
+  'publicId',
+  'external_id',
+  'externalId',
+  'id',
+];
+
+const LEGACY_KEYS = [
+  'legacyId',
+  'legacy_id',
+  'legacyID',
+  'legacyConversationId',
+  'legacy_conversation_id',
+  'conversationId',
+  'conversation_id',
+  'conversationID',
+  'id',
+];
+
+const SLUG_KEYS = [
+  'slug',
+  'conversationSlug',
+  'conversation_slug',
+  'conversation',
+  'public_id',
+  'publicId',
+  'external_id',
+  'externalId',
+];
+
+const NESTED_KEYS = [
+  'conversation',
+  'payload',
+  'data',
+  'event',
+  'details',
+  'meta',
+  'context',
+];
+
+const stripCtl = (value) =>
+  typeof value === 'string' ? value.replace(/[\u0000-\u001F\u007F]/g, '') : value;
+
+const clean = (value) => {
+  if (value == null) return '';
+  const stripped = stripCtl(value);
+  if (typeof stripped === 'string') return stripped.trim();
+  if (typeof stripped === 'number' && Number.isFinite(stripped)) return String(Math.trunc(stripped));
+  if (typeof stripped === 'bigint') return stripped.toString();
+  return '';
+};
+
+const looksLikeSlug = (value) => {
+  if (!value) return false;
+  if (UUID_RE.test(value) || LEGACY_RE.test(value)) return false;
+  if (/\s/.test(value)) return false;
+  return value.length >= 3 && value.length <= 128;
+};
+
+const pickFromKeys = (record, keys, predicate) => {
+  for (const key of keys) {
+    if (!(key in record)) continue;
+    const raw = clean(record[key]);
+    if (!raw) continue;
+    if (predicate(raw, key)) return { value: raw, key };
+  }
+  return null;
+};
+
+const inspectRecord = (record) => {
+  const uuid = pickFromKeys(record, UUID_KEYS, (value) => UUID_RE.test(value));
+  const legacy = pickFromKeys(record, LEGACY_KEYS, (value, key) => {
+    if (!LEGACY_RE.test(value)) return false;
+    // Avoid treating UUID-style keys as numeric IDs when the value already matches a UUID.
+    if (UUID_KEYS.includes(key) && UUID_RE.test(value)) return false;
+    return true;
+  });
+  let slug = pickFromKeys(record, SLUG_KEYS, (value) => looksLikeSlug(value));
+  if (!slug) {
+    slug = pickFromKeys(record, ['id', 'conversation'], (value) => looksLikeSlug(value));
+  }
+
+  const normalized = {
+    uuid: uuid ? uuid.value.toLowerCase() : null,
+    legacyId: legacy ? legacy.value : null,
+    slug: slug ? slug.value : null,
+    display: uuid?.value || legacy?.value || slug?.value || null,
+  };
+  return normalized;
+};
+
+const gatherRecords = (input) => {
+  const records = [];
+  const seen = new Set();
+  const stack = [];
+  if (input && typeof input === 'object') stack.push(input);
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current || typeof current !== 'object') continue;
+    if (seen.has(current)) continue;
+    seen.add(current);
+    records.push(current);
+    for (const key of NESTED_KEYS) {
+      const candidate = current[key];
+      if (candidate && typeof candidate === 'object' && !seen.has(candidate)) {
+        stack.push(candidate);
+      }
+    }
+  }
+  return records;
+};
+
+const mergeCandidates = (candidates) => {
+  const result = { uuid: null, legacyId: null, slug: null, display: null };
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    if (!result.uuid && candidate.uuid) result.uuid = candidate.uuid;
+    if (!result.legacyId && candidate.legacyId) result.legacyId = candidate.legacyId;
+    if (!result.slug && candidate.slug) result.slug = candidate.slug;
+    if (!result.display && candidate.display) result.display = candidate.display;
+  }
+  if (!result.display) {
+    result.display = result.uuid || result.legacyId || result.slug || null;
+  }
+  if (!result.uuid && !result.legacyId && !result.slug) return null;
+  return result;
+};
+
+export function normalizeAlertLinkInput(input) {
+  if (input == null) return null;
+  if (typeof input === 'string' || typeof input === 'number' || typeof input === 'bigint') {
+    const raw = clean(input);
+    if (!raw) return null;
+    if (UUID_RE.test(raw)) {
+      return { uuid: raw.toLowerCase(), legacyId: null, slug: null, display: raw };
+    }
+    if (LEGACY_RE.test(raw)) {
+      return { uuid: null, legacyId: raw, slug: null, display: raw };
+    }
+    if (looksLikeSlug(raw)) {
+      return { uuid: null, legacyId: null, slug: raw, display: raw };
+    }
+    return null;
+  }
+  if (typeof input !== 'object') return null;
+  const records = gatherRecords(input);
+  const candidates = records.map((record) => inspectRecord(record));
+  const merged = mergeCandidates(candidates);
+  if (!merged) return null;
+  return merged;
+}
+
+export async function buildAlertConversationLink(input, opts = {}) {
+  const normalized = normalizeAlertLinkInput(input);
+  if (!normalized) return null;
+  const builderInput = {
+    uuid: normalized.uuid || undefined,
+    legacyId: normalized.legacyId || undefined,
+    slug: normalized.slug || undefined,
+  };
+  const built = await buildUniversalConversationLink(builderInput, opts);
+  if (!built) return null;
+  const id = normalized.display || normalized.legacyId || normalized.slug || undefined;
+  const idDisplay = conversationIdDisplay({ uuid: normalized.uuid || undefined, id });
+  return {
+    ...built,
+    uuid: normalized.uuid || null,
+    legacyId: normalized.legacyId || null,
+    slug: normalized.slug || null,
+    idDisplay,
+  };
+}
+
+export const __test__ = {
+  clean,
+  looksLikeSlug,
+  inspectRecord,
+  gatherRecords,
+};


### PR DESCRIPTION
## Summary
- add a shared conversation link helper that normalizes identifiers and builds verified alert URLs
- simplify cron/check/mailer to use the shared builder and rely on resolver-aware alert links
- reuse internal resolver detail logic inside the universal link builder and extend tests for the new helper

## Testing
- npm test *(fails: Playwright browser binaries missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceffa0c518832ab48366bc9dd606fb