### PR TITLE
Prefer resolver links for minted fallbacks

### DIFF
--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -201,17 +201,19 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
       }
     }
 
-    const deep = `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(
-      uuid
-    )}`;
+    const deep = `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`;
     backupUrl = deep;
 
     if (mintedFallback) {
-      const ok = await verify(deep);
+      // Prefer server-side resolver when the uuid is a deterministic mint.
+      const resolverUrl = /^[0-9]+$/.test(fallbackRaw)
+        ? `${base}/r/legacy/${encodeURIComponent(fallbackRaw)}`
+        : `${base}/r/conversation/${encodeURIComponent(fallbackRaw)}`;
+      const ok = await verify(resolverUrl);
       if (!ok) return null;
-      url = deep;
+      url = resolverUrl;
       alreadyVerified = true;
-      kind = 'deep-link';
+      kind = 'resolver';
       minted = true;
     } else {
       // Prefer token link; if mint fails OR token verification fails, degrade to deep link.

--- a/tests/alert-conversation-link.spec.ts
+++ b/tests/alert-conversation-link.spec.ts
@@ -43,8 +43,9 @@ test.beforeEach(() => {
 test('ensureAlertConversationLink mints uuid for numeric identifier when resolvers fail', async () => {
   process.env.APP_URL = BASE;
   const calls: string[] = [];
+  const legacyId = 456;
   const link = await ensureAlertConversationLink(
-    { primary: 456 },
+    { primary: legacyId },
     {
       baseUrl: BASE,
       strictUuid: true,
@@ -55,13 +56,13 @@ test('ensureAlertConversationLink mints uuid for numeric identifier when resolve
       },
     },
   );
-  expect(calls).toEqual(['456']);
-  const expected = mintUuidFromRaw('456');
+  expect(calls).toEqual([String(legacyId)]);
+  const expected = mintUuidFromRaw(String(legacyId));
   expect(link?.uuid).toBe(expected);
-  expect(link?.kind).toBe('deep-link');
+  expect(link?.kind).toBe('resolver');
   expect(link?.minted).toBe(true);
   expect(link?.url).toBe(
-    `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(expected ?? '')}`
+    `${BASE}/r/legacy/${encodeURIComponent(String(legacyId))}`
   );
 });
 
@@ -84,10 +85,10 @@ test('ensureAlertConversationLink extracts slug from inline thread and mints whe
   );
   const expected = mintUuidFromRaw('inline-slug');
   expect(link?.uuid).toBe(expected);
-  expect(link?.kind).toBe('deep-link');
+  expect(link?.kind).toBe('resolver');
   expect(link?.minted).toBe(true);
   expect(link?.url).toBe(
-    `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(expected ?? '')}`
+    `${BASE}/r/conversation/${encodeURIComponent('inline-slug')}`
   );
 });
 


### PR DESCRIPTION
## Summary
- prefer resolver shortlinks when minting the conversation uuid from a fallback identifier
- keep deep link as the backup while verifying resolver URLs during mint fallback
- update alert link and conversation link tests to expect resolver links for minted identifiers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf2add9480832abab758ce2c7cc1f7