### PR TITLE
Enforce canonical minted links and tighten verification

### DIFF
--- a/apps/shared/lib/verifyLink.ts
+++ b/apps/shared/lib/verifyLink.ts
@@ -2,8 +2,9 @@ export async function verifyConversationLink(url: string): Promise<boolean> {
   try {
     const res = await fetch(url, { method: 'GET', redirect: 'manual' });
     if (res.status === 200) {
-      // Direct deep link rendered (SPA shell)
-      return true;
+      // Only accept a rendered deep link when it matches the canonical path
+      const u = new URL(url);
+      return /\/dashboard\/guest-experience\/all\b/.test(u.pathname);
     }
     // Accept any 3xx; verify Location header points to our login or deep link path
     if (res.status >= 300 && res.status < 400) {

--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -205,16 +205,27 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
     backupUrl = deep;
 
     if (mintedFallback) {
-      // Prefer server-side resolver when the uuid is a deterministic mint.
-      const resolverUrl = /^[0-9]+$/.test(fallbackRaw)
-        ? `${base}/r/legacy/${encodeURIComponent(fallbackRaw)}`
-        : `${base}/r/conversation/${encodeURIComponent(fallbackRaw)}`;
-      const ok = await verify(resolverUrl);
+      let mintedUuid = uuid || null;
+      if (!mintedUuid && fallbackRaw) {
+        try {
+          mintedUuid = mintUuidFromRaw(String(fallbackRaw)) || null;
+        } catch {
+          mintedUuid = null;
+        }
+      }
+      if (!mintedUuid) return null;
+      const canonicalUuid = mintedUuid.toLowerCase();
+      const mintedDeep = `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(
+        canonicalUuid
+      )}`;
+      const ok = await verify(mintedDeep);
       if (!ok) return null;
-      url = resolverUrl;
+      uuid = canonicalUuid;
+      url = mintedDeep;
       alreadyVerified = true;
-      kind = 'resolver';
+      kind = 'deep-link';
       minted = true;
+      backupUrl = mintedDeep;
     } else {
       // Prefer token link; if mint fails OR token verification fails, degrade to deep link.
       let candidate = null;

--- a/tests/alert-conversation-link.spec.ts
+++ b/tests/alert-conversation-link.spec.ts
@@ -59,10 +59,10 @@ test('ensureAlertConversationLink mints uuid for numeric identifier when resolve
   expect(calls).toEqual([String(legacyId)]);
   const expected = mintUuidFromRaw(String(legacyId));
   expect(link?.uuid).toBe(expected);
-  expect(link?.kind).toBe('resolver');
+  expect(link?.kind).toBe('deep-link');
   expect(link?.minted).toBe(true);
   expect(link?.url).toBe(
-    `${BASE}/r/legacy/${encodeURIComponent(String(legacyId))}`
+    `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(expected)}`
   );
 });
 
@@ -85,10 +85,10 @@ test('ensureAlertConversationLink extracts slug from inline thread and mints whe
   );
   const expected = mintUuidFromRaw('inline-slug');
   expect(link?.uuid).toBe(expected);
-  expect(link?.kind).toBe('resolver');
+  expect(link?.kind).toBe('deep-link');
   expect(link?.minted).toBe(true);
   expect(link?.url).toBe(
-    `${BASE}/r/conversation/${encodeURIComponent('inline-slug')}`
+    `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(expected)}`
   );
 });
 

--- a/tests/alert-link.spec.ts
+++ b/tests/alert-link.spec.ts
@@ -157,8 +157,9 @@ test('buildUniversalConversationLink mints fallback uuid when strict mode enable
     { slug },
     { baseUrl: BASE, verify: async () => true, strictUuid: true }
   );
-  const expected = `${BASE}/r/conversation/${encodeURIComponent(slug)}`;
-  expect(res?.kind).toBe('resolver');
+  const minted = mintUuidFromRaw(slug);
+  const expected = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(minted)}`;
+  expect(res?.kind).toBe('deep-link');
   expect(res?.minted).toBe(true);
   expect(res?.url).toBe(expected);
 });
@@ -171,8 +172,9 @@ test('buildUniversalConversationLink uses resolver(s) to obtain uuid; mints when
     { legacyId },
     { baseUrl: BASE, verify: async () => true, strictUuid: true }
   );
-  const expected = `${BASE}/r/legacy/${encodeURIComponent(String(legacyId))}`;
-  expect(res?.kind).toBe('resolver');
+  const minted = mintUuidFromRaw(String(legacyId));
+  const expected = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(minted)}`;
+  expect(res?.kind).toBe('deep-link');
   expect(res?.minted).toBe(true);
   expect(res?.url).toBe(expected);
 });
@@ -247,8 +249,8 @@ test('buildUniversalConversationLink uses resolver link when resolver mints uuid
       },
     }
   );
-  const expected = `${BASE}/r/legacy/${encodeURIComponent(String(legacyId))}`;
-  expect(res?.kind).toBe('resolver');
+  const expected = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`;
+  expect(res?.kind).toBe('deep-link');
   expect(res?.minted).toBe(true);
   expect(res?.url).toBe(expected);
   expect(seen).toEqual([expected]);
@@ -270,8 +272,8 @@ test('buildUniversalConversationLink uses resolver link when resolver mints uuid
       },
     }
   );
-  const expected = `${BASE}/r/conversation/${encodeURIComponent(slug)}`;
-  expect(res?.kind).toBe('resolver');
+  const expected = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`;
+  expect(res?.kind).toBe('deep-link');
   expect(res?.minted).toBe(true);
   expect(res?.url).toBe(expected);
   expect(seen).toEqual([expected]);
@@ -294,8 +296,8 @@ test('buildUniversalConversationLink detects minted fallback without resolver de
       },
     }
   );
-  const expected = `${BASE}/r/conversation/${encodeURIComponent(slug)}`;
-  expect(res?.kind).toBe('resolver');
+  const expected = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(minted)}`;
+  expect(res?.kind).toBe('deep-link');
   expect(res?.minted).toBe(true);
   expect(res?.url).toBe(expected);
   expect(seen).toEqual([expected]);
@@ -366,7 +368,7 @@ test('buildUniversalConversationLink verifies resolver link when resolver indica
     return { ok: true, json: async () => ({}) } as any;
   };
   const legacyId = '12345';
-  const expected = `${BASE}/r/legacy/${encodeURIComponent(legacyId)}`;
+  const expected = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`;
   const res = await buildUniversalConversationLink(
     { uuid, legacyId },
     {
@@ -379,7 +381,7 @@ test('buildUniversalConversationLink verifies resolver link when resolver indica
     }
   );
   global.fetch = originalFetch as any;
-  expect(res?.kind).toBe('resolver');
+  expect(res?.kind).toBe('deep-link');
   expect(res?.minted).toBe(true);
   expect(res?.url).toBe(expected);
 });
@@ -416,8 +418,8 @@ test('buildUniversalConversationLink uses resolver link for minted identifiers e
       },
     }
   );
-  const expected = `${BASE}/r/legacy/${encodeURIComponent(String(legacyId))}`;
-  expect(res?.kind).toBe('resolver');
+  const expected = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`;
+  expect(res?.kind).toBe('deep-link');
   expect(res?.minted).toBe(true);
   expect(res?.url).toBe(expected);
   expect(seen).toEqual([expected]);


### PR DESCRIPTION
## Summary
- restrict verifyConversationLink 200 responses to the canonical guest experience deep link
- emit canonical dashboard deep links for minted conversation identifiers and align tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf31cf3d78832a8899ba415bc0386c