### PR TITLE
Enforce signed alert links and add dashboard resolver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,4 @@ LINK_AUDIENCE=boom-app
 
 # Optional single-use enforcement
 # REDIS_URL=redis://localhost:6379
+REQUIRE_SIGNED_ALERT_LINKS=0  # set to 1 in production to forbid raw deep links

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Key properties:
 - **Safe-link resilience** – The redirector unwraps nested `?url=` parameters and double-encoded paths to survive external redirectors.
 - **Fallback UX** – Expired or tampered tokens drop users on `/link/help`, a static landing page with retry instructions. When a legacy ID is present we still forward to `/dashboard/guest-experience/cs?legacyId=<id>`.
 
+Production guardrails:
+
+- Production **must** set `REQUIRE_SIGNED_ALERT_LINKS=1` so the mailer refuses to emit raw deep links.
+- If you ever see deep links in email HTML, double-check `LINK_PRIVATE_JWK` and `ALERT_LINK_BASE` on the worker deployment.
+- Optional: allow-list `go.boomnow.com` (or your custom `ALERT_LINK_BASE`) in Microsoft Safe Links to keep tokens intact.
+
 ### Operations cheatsheet
 
 - Populate the following env vars (see `.env.example`):

--- a/app/api/resolve/conversation/route.ts
+++ b/app/api/resolve/conversation/route.ts
@@ -1,8 +1,13 @@
 import { prisma } from '../../../../lib/db';
 import { redis } from '../../../../lib/redis';
 import { metrics } from '../../../../lib/metrics';
+import { resolveConversation } from '../../../../packages/linking/src/index.js';
 
-const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const CACHE_HEADERS = { 'Cache-Control': 'no-store' };
+const CACHE_TTL_SECONDS = 7 * 24 * 3600;
 
 async function dbLookup(legacyId: number) {
   const alias = await prisma.conversation_aliases.findUnique({ where: { legacy_id: legacyId } });
@@ -31,27 +36,117 @@ function json(body: any, init: ResponseInit) {
   });
 }
 
-export async function GET(req: Request) {
-  const { searchParams } = new URL(req.url);
-  const legacy = searchParams.get('legacyId');
-  if (!legacy || !/^\d+$/.test(legacy)) {
-    return json({ error: 'bad_request' }, { status: 400 });
-  }
-  const legacyId = Number(legacy);
+function normalize(value: string | null) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+async function legacyUuid(legacyId: number) {
   const cacheKey = `conv:alias:legacy:${legacyId}`;
   const cached = typeof redis?.get === 'function' ? await redis.get(cacheKey) : null;
   if (cached && UUID_RE.test(String(cached))) {
     metrics.increment('conv_alias.cache_hit');
-    return json({ uuid: String(cached).toLowerCase() }, { status: 200, headers: { 'Cache-Control': 'no-store' } });
+    return String(cached).toLowerCase();
   }
 
   const uuid = await dbLookup(legacyId);
   if (uuid) {
     metrics.increment('conv_alias.db_hit');
-    if (redis) await redis.set(cacheKey, uuid, { EX: 7 * 24 * 3600 });
-    return json({ uuid }, { status: 200, headers: { 'Cache-Control': 'no-store' } });
+    if (redis) await redis.set(cacheKey, uuid, { EX: CACHE_TTL_SECONDS });
+    return uuid;
   }
 
   metrics.increment('conv_alias.not_found');
-  return json({ error: 'not_found' }, { status: 404 });
+  return null;
+}
+
+function cacheResolvedLegacy(legacyId: number, uuid: string) {
+  if (!redis) return;
+  const cacheKey = `conv:alias:legacy:${legacyId}`;
+  redis.set(cacheKey, uuid, { EX: CACHE_TTL_SECONDS }).catch(() => {});
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const raw = normalize(searchParams.get('raw'));
+  const uuidParam = normalize(searchParams.get('uuid'));
+  const legacyParam = normalize(searchParams.get('legacyId'));
+  const slugParam = normalize(searchParams.get('slug'));
+
+  let uuidCandidate = uuidParam && UUID_RE.test(uuidParam) ? uuidParam.toLowerCase() : null;
+  let legacyCandidate = legacyParam && /^\d+$/.test(legacyParam) ? Number(legacyParam) : null;
+  let slugCandidate = slugParam || null;
+
+  if (raw) {
+    if (!uuidCandidate && UUID_RE.test(raw)) {
+      uuidCandidate = raw.toLowerCase();
+    } else if (!legacyCandidate && /^\d+$/.test(raw)) {
+      legacyCandidate = Number(raw);
+    } else if (!slugCandidate) {
+      slugCandidate = raw;
+    }
+  }
+
+  if (uuidCandidate) {
+    try {
+      const resolved = await resolveConversation({
+        uuid: uuidCandidate,
+        skipRedirectProbe: true,
+      });
+      if (resolved?.uuid) {
+        return json({ uuid: resolved.uuid }, { status: 200, headers: CACHE_HEADERS });
+      }
+    } catch {
+      // fall through to return the candidate uuid below
+    }
+    return json({ uuid: uuidCandidate }, { status: 200, headers: CACHE_HEADERS });
+  }
+
+  if (legacyCandidate != null) {
+    const resolved = await resolveConversation({
+      legacyId: String(legacyCandidate),
+      allowMintFallback: false,
+      skipRedirectProbe: true,
+    }).catch(() => null);
+    if (resolved?.uuid && UUID_RE.test(resolved.uuid)) {
+      const normalizedUuid = resolved.uuid.toLowerCase();
+      let enrichedUuid: string | null = null;
+      try {
+        enrichedUuid = await dbLookup(legacyCandidate);
+      } catch {
+        enrichedUuid = null;
+      }
+      const finalUuid = enrichedUuid && UUID_RE.test(enrichedUuid) ? enrichedUuid : normalizedUuid;
+      cacheResolvedLegacy(legacyCandidate, finalUuid);
+      if (!enrichedUuid) {
+        await prisma.conversation_aliases.upsert({
+          where: { legacy_id: legacyCandidate },
+          create: { legacy_id: legacyCandidate, uuid: finalUuid },
+          update: { uuid: finalUuid, last_seen_at: new Date() },
+        });
+      }
+      return json({ uuid: finalUuid }, { status: 200, headers: CACHE_HEADERS });
+    }
+
+    const uuid = await legacyUuid(legacyCandidate);
+    if (uuid) {
+      return json({ uuid }, { status: 200, headers: CACHE_HEADERS });
+    }
+    return json({ error: 'not_found' }, { status: 404, headers: CACHE_HEADERS });
+  }
+
+  if (slugCandidate) {
+    const resolved = await resolveConversation({
+      slug: slugCandidate,
+      allowMintFallback: true,
+      skipRedirectProbe: true,
+    }).catch(() => null);
+    if (resolved?.uuid && UUID_RE.test(resolved.uuid)) {
+      return json({ uuid: resolved.uuid.toLowerCase() }, { status: 200, headers: CACHE_HEADERS });
+    }
+    return json({ error: 'not_found' }, { status: 404, headers: CACHE_HEADERS });
+  }
+
+  return json({ error: 'bad_request' }, { status: 400, headers: CACHE_HEADERS });
 }

--- a/app/dashboard/guest-experience/all/ConversationResolver.tsx
+++ b/app/dashboard/guest-experience/all/ConversationResolver.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import GuestExperience from './GuestExperience';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type Props = {
+  initialConversationId?: string;
+};
+
+export default function ConversationResolver({
+  initialConversationId,
+}: Props) {
+  const [conversationId, setConversationId] = useState<string | undefined>();
+  const [resolverError, setResolverError] = useState(false);
+
+  useEffect(() => {
+    if (!initialConversationId) {
+      setConversationId(undefined);
+      setResolverError(false);
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+
+    async function resolve() {
+      try {
+        setResolverError(false);
+        const raw = String(initialConversationId);
+        const res = await fetch(
+          `/api/resolve/conversation?raw=${encodeURIComponent(raw)}`,
+          { signal: controller.signal }
+        );
+        if (!res.ok) {
+          throw new Error(`resolve_failed:${res.status}`);
+        }
+        const data = await res.json();
+        if (cancelled) return;
+
+        if (data?.uuid) {
+          const normalized = String(data.uuid).toLowerCase();
+          setConversationId(normalized);
+          if (
+            normalized &&
+            typeof window !== 'undefined' &&
+            window.history &&
+            normalized !== raw.toLowerCase()
+          ) {
+            try {
+              const currentUrl = new URL(window.location.href);
+              currentUrl.searchParams.set('conversation', normalized);
+              window.history.replaceState(
+                window.history.state,
+                '',
+                `${currentUrl.pathname}?${currentUrl.search}`
+              );
+            } catch {
+              // ignore history failures
+            }
+          }
+          return;
+        }
+
+        if (data?.legacyId) {
+          if (typeof window !== 'undefined') {
+            const destination = `/dashboard/guest-experience/cs?legacyId=${encodeURIComponent(
+              String(data.legacyId)
+            )}`;
+            window.location.replace(destination);
+          }
+          return;
+        }
+
+        throw new Error('resolve_invalid');
+      } catch (err) {
+        if (cancelled || controller.signal.aborted) return;
+        setConversationId(undefined);
+        setResolverError(true);
+      }
+    }
+
+    setConversationId(undefined);
+    resolve();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [initialConversationId]);
+
+  const resolvedConversation =
+    typeof conversationId === 'string' && UUID_RE.test(conversationId)
+      ? conversationId
+      : undefined;
+
+  return (
+    <>
+      {resolverError ? (
+        <div
+          role="alert"
+          style={{
+            margin: '16px',
+            padding: '12px 16px',
+            borderRadius: '8px',
+            background: '#fef2f2',
+            color: '#7f1d1d',
+            fontSize: '0.875rem',
+          }}
+        >
+          We couldn't resolve that conversation link.{' '}
+          <a
+            href="/link/help"
+            style={{ color: '#7f1d1d', textDecoration: 'underline' }}
+          >
+            Get help
+          </a>
+          .
+        </div>
+      ) : null}
+      <GuestExperience initialConversationId={resolvedConversation} />
+    </>
+  );
+}

--- a/app/dashboard/guest-experience/all/page.tsx
+++ b/app/dashboard/guest-experience/all/page.tsx
@@ -1,8 +1,5 @@
 import { redirect } from 'next/navigation';
-import GuestExperience from './GuestExperience';
-
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+import ConversationResolver from './ConversationResolver';
 
 export default function Page({ searchParams }: { searchParams: { conversation?: string; legacyId?: string } }) {
   const conversation =
@@ -14,11 +11,7 @@ export default function Page({ searchParams }: { searchParams: { conversation?: 
       ? searchParams.legacyId
       : undefined;
 
-  // Forward non-UUID/legacy to the client-side resolver to avoid redirect loops.
   if (legacyId) redirect(`/dashboard/guest-experience/cs?legacyId=${encodeURIComponent(legacyId)}`);
-  if (conversation && !UUID_RE.test(conversation)) {
-    redirect(`/dashboard/guest-experience/cs?conversation=${encodeURIComponent(conversation)}`);
-  }
 
-  return <GuestExperience initialConversationId={conversation} />;
+  return <ConversationResolver initialConversationId={conversation} />;
 }

--- a/tests/conversation-link.spec.ts
+++ b/tests/conversation-link.spec.ts
@@ -228,7 +228,7 @@ test('mailer mints uuid when canonical mapping missing (strict mode)', async () 
   }
   expect(emails.length).toBe(1);
   const minted = mintUuidFromRaw('789');
-  expect(emails[0].html).toContain(`conversation=${encodeURIComponent(minted ?? '')}`);
+  expect(emails[0].html).toContain(`/c/${encodeURIComponent(minted ?? '')}`);
   expect(metricsArr).toContain('alerts.sent_with_minted_link');
 });
 
@@ -257,6 +257,6 @@ test('mailer mints uuid for slug when resolver unavailable', async () => {
   }
   expect(emails.length).toBe(1);
   const minted = mintUuidFromRaw(slug);
-  expect(emails[0].html).toContain(`conversation=${encodeURIComponent(minted ?? '')}`);
+  expect(emails[0].html).toContain(`/c/${encodeURIComponent(minted ?? '')}`);
   expect(metricsArr).toContain('alerts.sent_with_minted_link');
 });

--- a/tests/verify-link-redirects.spec.ts
+++ b/tests/verify-link-redirects.spec.ts
@@ -1,5 +1,25 @@
 import { test, expect } from '@playwright/test';
+import { buildAlertEmail } from '../apps/worker/mailer/alerts';
 import { verifyConversationLink } from '../apps/shared/lib/verifyLink';
+import { setTestKeyEnv } from './helpers/testKeys';
+
+function snapshotEnv(keys: string[]) {
+  const snapshot = new Map<string, string | undefined>();
+  for (const key of keys) {
+    snapshot.set(key, process.env[key]);
+  }
+  return {
+    restore() {
+      for (const [key, value] of snapshot.entries()) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    },
+  };
+}
 
 test('verifyConversationLink accepts 303/307/308 to login or deep link', async () => {
   const orig = global.fetch;
@@ -25,5 +45,70 @@ test('verifyConversationLink accepts 303/307/308 to login or deep link', async (
     await expect(verifyConversationLink('https://example.com/x')).resolves.toBe(false);
   } finally {
     global.fetch = orig as any;
+  }
+});
+
+test('mailer emits /u/<jwt> in production', async () => {
+  const uuid = '01890b14-b4cd-7eef-b13e-bb8c083bad60';
+  const env = snapshotEnv([
+    'REQUIRE_SIGNED_ALERT_LINKS',
+    'ALERT_LINK_BASE',
+    'TARGET_APP_URL',
+    'LINK_PRIVATE_JWK',
+    'LINK_PUBLIC_JWKS',
+    'LINK_KID',
+    'LINK_ISSUER',
+    'LINK_AUDIENCE',
+    'LINK_JWKS_URL',
+    'LINK_SECRET',
+    'LINK_PRIVATE_KEY_PEM',
+    'LINK_PUBLIC_KEY_PEM',
+  ]);
+  try {
+    process.env.REQUIRE_SIGNED_ALERT_LINKS = '1';
+    process.env.ALERT_LINK_BASE = 'https://go.example.com';
+    process.env.TARGET_APP_URL = 'https://app.example.com';
+    setTestKeyEnv();
+
+    const html = await buildAlertEmail({ conversation_uuid: uuid }, { verify: async () => true });
+    expect(html).toBeTruthy();
+    const href = html?.match(/href="([^"]+)"/i)?.[1];
+    expect(href).toBeDefined();
+    expect(href?.startsWith('https://go.example.com/u/')).toBe(true);
+  } finally {
+    env.restore();
+  }
+});
+
+test('guard blocks when keys missing', async () => {
+  const uuid = '01890b14-b4cd-7eef-b13e-bb8c083bad60';
+  const env = snapshotEnv([
+    'REQUIRE_SIGNED_ALERT_LINKS',
+    'ALERT_LINK_BASE',
+    'TARGET_APP_URL',
+    'LINK_PRIVATE_JWK',
+    'LINK_PUBLIC_JWKS',
+    'LINK_KID',
+    'LINK_ISSUER',
+    'LINK_AUDIENCE',
+    'LINK_JWKS_URL',
+    'LINK_SECRET',
+    'LINK_PRIVATE_KEY_PEM',
+    'LINK_PUBLIC_KEY_PEM',
+  ]);
+  try {
+    process.env.REQUIRE_SIGNED_ALERT_LINKS = '1';
+    process.env.ALERT_LINK_BASE = 'https://go.example.com';
+    process.env.TARGET_APP_URL = 'https://app.example.com';
+    setTestKeyEnv();
+    delete process.env.LINK_PRIVATE_JWK;
+
+    await expect(
+      buildAlertEmail({ conversation_uuid: uuid }, { verify: async () => true })
+    ).rejects.toThrow(
+      /Signed alert links required/
+    );
+  } finally {
+    env.restore();
   }
 });


### PR DESCRIPTION
## Summary
- require configured signing keys when mailing alerts and emit resolver shortlinks for fallbacks
- add a client-side dashboard resolver backed by a universal `/api/resolve/conversation` endpoint
- harden the redirector target validation and document the new REQUIRE_SIGNED_ALERT_LINKS guard

## Testing
- npm test *(fails: Playwright browsers require additional system libraries)*
- npx playwright test tests/resolve-conversation.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cf4e9ac29c832aac25cbb72a241bba