### PR TITLE
Avoid CS deep links for alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,66 @@
-# Name
-### boom-sla-check
+# boom-sla-check
 
-# Synopsis
+Boom's SLA monitor ingests guest conversations, identifies unanswered threads, and emits signed alert links that resolve safely through the redirector. The project also hosts lightweight dashboard routes used by deep links in email and support tooling.
 
+## Installation
 
-# Description
-
-# Example
-
-# Install:
-`npm install boom-sla-check`
-
-# Test:
-`npm test`
-
-## Environment Variables
-
-- `BOOM_API_BASE` – base URL for Boom API
-- `BOOM_API_TOKEN` – API token for authentication
-- `BOOM_ORG_ID` – organization/account identifier
-- `(Optional) CHECK_BATCH_SIZE` – batch size for downstream processing
-- `LIST_LIMIT_PARAM` – name of the query parameter controlling page size when listing conversations
-- `LIST_OFFSET_PARAM` – name of the query parameter controlling list offset or page number
-- `PAGE_SIZE` – number of conversations per page (defaults to 30)
-The cron job now fetches the first two pages of the conversations list (≈30 per page), supporting both limit/offset and page-based APIs.
-
-## Email Links: Architecture, JWKS, and Redirector
-
-Alert emails now ship with a hardened redirect flow. The mailer signs a short-lived Ed25519 JWT that encodes the target conversation identifiers, and the lightweight redirector app (see `apps/redirector`) validates the token before forwarding the user to the canonical dashboard URL.
-
-```
-mailer ──signLink()──▶ go.boomnow.com/u/<jwt> ──verifyLink() + resolveConversation()──▶ https://app.boomnow.com/dashboard/guest-experience/all?conversation=<uuid>
+```bash
+npm install
 ```
 
-Key properties:
+## Testing
 
-- **Ed25519 tokens** – Links are signed with `LINK_PRIVATE_JWK` and verified against the rotate-ready JWKS served from `/.well-known/jwks.json`.
-- **Stateless redirector** – The Hono-based redirector honours both `GET` and `HEAD` requests, always answers with `303 See Other`, and sets `Cache-Control: no-store`, `Referrer-Policy: no-referrer`, and `X-Robots-Tag: noindex, nosnippet`.
-- **Conversation resolution** – Incoming tokens and `/c/:raw` lookups are normalised via `packages/linking`, which prefers in-memory/DB hits and falls back to the public resolver before minting.
-- **Safe-link resilience** – The redirector unwraps nested `?url=` parameters and double-encoded paths to survive external redirectors.
-- **Fallback UX** – Expired or tampered tokens drop users on `/link/help`, a static landing page with retry instructions. When a legacy ID is present we still forward to `/dashboard/guest-experience/cs?legacyId=<id>`.
+```bash
+npm test
+```
 
-Production guardrails:
+## Environment configuration
 
-- Production **must** set `REQUIRE_SIGNED_ALERT_LINKS=1` so the mailer refuses to emit raw deep links.
-- If you ever see deep links in email HTML, double-check `LINK_PRIVATE_JWK` and `ALERT_LINK_BASE` on the worker deployment.
-- Optional: allow-list `go.boomnow.com` (or your custom `ALERT_LINK_BASE`) in Microsoft Safe Links to keep tokens intact.
+### Core Boom credentials & URLs
 
-### Operations cheatsheet
+Set the following variables so the check and cron runners can authenticate against the Boom app:
 
-- Populate the following env vars (see `.env.example`):
-  - `ALERT_LINK_BASE` (e.g. `https://go.boomnow.com`)
-  - `TARGET_APP_URL` (e.g. `https://app.boomnow.com`)
-  - `LINK_PRIVATE_JWK`, `LINK_PUBLIC_JWKS`, `LINK_KID`, `LINK_ISSUER`, `LINK_AUDIENCE`
-- Rotate keys by appending the new JWK to `LINK_PUBLIC_JWKS`, deploying the redirector, then updating the mailer `LINK_PRIVATE_JWK` and `LINK_KID`.
-- Local development: `pnpm dev:redirector` runs the redirector on port `3005` (use `pnpm deploy:redirector` for production parity).
-- Existing `/r/*` Next.js routes remain available for local debugging, but new outbound mail links should point at `https://go.boomnow.com/u/<jwt>` immediately.
-- For back-compat on the main app host, issue a temporary `308` from `app.boomnow.com/r/*` to `go.boomnow.com/c/*` until old links age out.
+- `APP_URL` – canonical application host (defaults to `https://app.boomnow.com`).
+- `BOOM_USER` / `BOOM_PASS` – login credentials used when cookies or bearer tokens are unavailable.
+- `BOOM_COOKIE` – optional pre-authenticated cookie header for direct API access.
+- `BOOM_TOKEN` / `BOOM_BEARER` – optional bearer tokens used to call Boom APIs.
+- `BOOM_API_BASE` – REST API base URL used by helper scripts (for example `https://api.boomnow.com`).
+- `BOOM_API_TOKEN` – API token used with `BOOM_API_BASE`.
+- `BOOM_ORG_ID` – organisation/account scope applied to API calls.
+- `LOGIN_URL`, `LOGIN_METHOD`, `LOGIN_CT`, `LOGIN_EMAIL_FIELD`, `LOGIN_PASSWORD_FIELD`, `LOGIN_TENANT_FIELD` – customise interactive login when the job needs to bootstrap a session.
+- `CONVERSATIONS_URL` – API endpoint that lists conversations for the cron sweep.
+- `MESSAGES_URL` – API endpoint template for fetching a conversation thread. Include `{{conversationId}}` so the scripts can substitute the lookup identifier, for example `https://app.boomnow.com/api/conversations/{{conversationId}}/messages`.
 
-#License:
+### Conversation list & selection controls
+
+- `LIST_LIMIT_PARAM` – query parameter that controls page size when fetching the conversations list.
+- `LIST_OFFSET_PARAM` – query parameter that controls pagination (`offset`, `page`, etc.).
+- `PAGE_SIZE` – expected page size (defaults to `30`).
+- `CHECK_LIMIT` – hard cap on the number of conversations the cron job evaluates per run.
+
+> The cron sweep always requests the first two pages (~30 items per page) and deduplicates results before selecting the objectively newest window of conversations.
+
+### Alert links and redirector
+
+- `ALERT_LINK_BASE` – host that serves signed redirector links (for example `https://go.boomnow.com`).
+- `TARGET_APP_URL` – Boom app base URL used by the redirector when building deep links.
+- `LINK_PRIVATE_JWK` – Ed25519 private key (JWK format) used to sign alert tokens.
+- `LINK_PUBLIC_JWKS` – JWKS bundle containing the corresponding public keys. The redirector caches this JWKS for 60 seconds.
+- `LINK_KID` – key identifier embedded in signed tokens.
+- `LINK_ISSUER` / `LINK_AUDIENCE` – issuer and audience claims enforced by the redirector when verifying tokens.
+
+### Conversation UUID namespace
+
+- `CONVERSATION_UUID_NAMESPACE` – UUID namespace used for deterministic UUIDv5 minting when a legacy id or slug needs a stable fallback. Defaults to `3f3aa693-5b5d-4f6a-9c8e-7b7a1d1d8b7a`.
+
+### Internal resolution
+
+- `RESOLVE_BASE_URL` – Boom app host that exposes `/api/internal/resolve-conversation` for HMAC-authenticated lookups.
+- `RESOLVE_SECRET` – shared secret used to sign internal resolve requests.
+
+These settings allow the jobs to resolve canonical UUIDs, construct verified deep links, and mail operators without exposing raw identifiers.
+
+## Redirector behaviour
+
+The stateless redirector (`apps/redirector`) verifies Ed25519 tokens against `LINK_PUBLIC_JWKS`, unwraps nested redirect parameters, and forwards users with `303 See Other` responses. Invalid or expired tokens fall back to `/link/help`; if a legacy conversation id is present, the redirector sends users to `/dashboard/guest-experience/all?legacyId=<id>` instead of the legacy CS route.
 

--- a/app/c/[id]/route.ts
+++ b/app/c/[id]/route.ts
@@ -8,8 +8,13 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
   const raw = params.id;
   const uuid = await tryResolveConversationUuid(raw);
   const base = appUrlFromRequest(req);
-  const to = uuid
-    ? conversationDeepLinkFromUuid(uuid, { baseUrl: base })
-    : `${base}/dashboard/guest-experience/cs?conversation=${encodeURIComponent(raw)}`;
+  let to: string;
+  if (uuid) {
+    to = conversationDeepLinkFromUuid(uuid, { baseUrl: base });
+  } else if (/^\d+$/.test(raw)) {
+    to = `${base}/dashboard/guest-experience/all?legacyId=${encodeURIComponent(raw)}`;
+  } else {
+    to = `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(raw)}`;
+  }
   return NextResponse.redirect(to, 302);
 }

--- a/app/dashboard/guest-experience/all/page.tsx
+++ b/app/dashboard/guest-experience/all/page.tsx
@@ -1,17 +1,19 @@
-import { redirect } from 'next/navigation';
 import ConversationResolver from './ConversationResolver';
 
 export default function Page({ searchParams }: { searchParams: { conversation?: string; legacyId?: string } }) {
   const conversation =
-    typeof searchParams.conversation === 'string' && searchParams.conversation.length > 0
-      ? searchParams.conversation
+    typeof searchParams.conversation === 'string' && searchParams.conversation.trim().length > 0
+      ? searchParams.conversation.trim()
       : undefined;
   const legacyId =
-    typeof searchParams.legacyId === 'string' && searchParams.legacyId.length > 0
-      ? searchParams.legacyId
+    typeof searchParams.legacyId === 'string' && searchParams.legacyId.trim().length > 0
+      ? searchParams.legacyId.trim()
       : undefined;
 
-  if (legacyId) redirect(`/dashboard/guest-experience/cs?legacyId=${encodeURIComponent(legacyId)}`);
-
-  return <ConversationResolver initialConversationId={conversation} />;
+  return (
+    <ConversationResolver
+      initialConversationId={conversation}
+      initialLegacyId={legacyId}
+    />
+  );
 }

--- a/apps/redirector/app.js
+++ b/apps/redirector/app.js
@@ -219,7 +219,7 @@ function getAudience() {
 
 function buildLegacyFallback(legacyId) {
   const base = cleanBaseUrl();
-  const url = new URL('/dashboard/guest-experience/cs', base + '/');
+  const url = new URL('/dashboard/guest-experience/all', base + '/');
   url.searchParams.set('legacyId', String(legacyId));
   return url.toString();
 }

--- a/packages/linking/src/deeplink.js
+++ b/packages/linking/src/deeplink.js
@@ -1,5 +1,5 @@
 const UUID_PATH = '/dashboard/guest-experience/all';
-const LEGACY_PATH = '/dashboard/guest-experience/cs';
+const LEGACY_PATH = '/dashboard/guest-experience/all';
 
 function cleanBase(url) {
   const raw = String(url || '').trim();

--- a/tests/linking-deeplink.spec.ts
+++ b/tests/linking-deeplink.spec.ts
@@ -8,7 +8,7 @@ test('buildCanonicalDeepLink prefers uuid route', () => {
 
 test('buildCanonicalDeepLink falls back to legacy id', () => {
   const url = buildCanonicalDeepLink({ appUrl: 'https://app.example.com/', legacyId: 42 });
-  expect(url).toBe('https://app.example.com/dashboard/guest-experience/cs?legacyId=42');
+  expect(url).toBe('https://app.example.com/dashboard/guest-experience/all?legacyId=42');
 });
 
 test('buildCanonicalDeepLink throws without identifier', () => {

--- a/tests/redirector.spec.ts
+++ b/tests/redirector.spec.ts
@@ -63,7 +63,7 @@ test('GET /u/:token with expired JWT redirects to legacy fallback', async () => 
   const res = await app.fetch(new Request(`http://redirect.example/u/${token}`, { method: 'GET' }));
   expect(res.status).toBe(303);
   expect(res.headers.get('location')).toBe(
-    'https://app.example.com/dashboard/guest-experience/cs?legacyId=1010993'
+    'https://app.example.com/dashboard/guest-experience/all?legacyId=1010993'
   );
 });
 


### PR DESCRIPTION
## Summary
- document the SLA monitor environment requirements and redirector behaviour in the README
- keep conversation deep links on /dashboard/guest-experience/all, including redirector fallbacks and the Next.js resolver
- adjust canonical link utilities and tests so legacy IDs now resolve through the All view

## Testing
- npm ci
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf5b025e5c832a9041e2357f7d1703