### PR TITLE
fix: stable deep links for SLA alerts; guard selected conversation access

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,5 +75,5 @@ The hedged resolver emits spans named `resolveConversationUuidHedged`, and alert
 
 ## Redirector behaviour
 
-The stateless redirector (`apps/redirector`) verifies Ed25519 tokens against `LINK_PUBLIC_JWKS`, unwraps nested redirect parameters, and forwards users with `303 See Other` responses. Invalid or expired tokens fall back to `/link/help`; if a legacy conversation id is present, the redirector sends users to `/dashboard/guest-experience/all?legacyId=<id>` instead of the legacy CS route.
+The stateless redirector (`apps/redirector`) verifies Ed25519 tokens against `LINK_PUBLIC_JWKS`, unwraps nested redirect parameters, and forwards users with `303 See Other` responses. Invalid or expired tokens fall back to `/link/help`; if a legacy conversation id is present, the redirector sends users to `/go/c/<id>` instead of the legacy CS route.
 

--- a/app/c/[id]/route.ts
+++ b/app/c/[id]/route.ts
@@ -11,10 +11,8 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
   let to: string;
   if (uuid) {
     to = conversationDeepLinkFromUuid(uuid, { baseUrl: base });
-  } else if (/^\d+$/.test(raw)) {
-    to = `${base}/dashboard/guest-experience/all?legacyId=${encodeURIComponent(raw)}`;
   } else {
-    to = `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(raw)}`;
+    to = `${base}/go/c/${encodeURIComponent(raw)}`;
   }
   return NextResponse.redirect(to, 302);
 }

--- a/app/conversations/[id]/route.ts
+++ b/app/conversations/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server.js';
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
-  const url = new URL('/dashboard/guest-experience/all', req.url);
-  url.searchParams.set('conversation', params.id);
+  const base = new URL(req.url);
+  const url = new URL(`/go/c/${encodeURIComponent(params.id)}`, base.origin);
   return NextResponse.redirect(url, { status: 307 });
 }

--- a/app/dashboard/guest-experience/all/GuestExperience.tsx
+++ b/app/dashboard/guest-experience/all/GuestExperience.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo } from 'react';
 import { normalizeConversation } from '../../../../src/conversation';
+import type { Conversation } from '../../../../src/conversation';
 import { useConversation } from './useConversation';
 
 function SkeletonConversation() {
@@ -31,6 +32,11 @@ export function conversationViewState(args: {
   return 'ready';
 }
 
+export function safeRelatedReservations(conversation?: Conversation | null) {
+  const related = conversation?.related_reservations;
+  return Array.isArray(related) ? related : [];
+}
+
 export default function GuestExperience({ initialConversationId }: { initialConversationId?: string }) {
   const { data, isLoading, error } = useConversation(initialConversationId);
 
@@ -47,8 +53,11 @@ export default function GuestExperience({ initialConversationId }: { initialConv
   });
 
   useEffect(() => {
-    if (initialConversationId && data) openDrawer(initialConversationId);
-  }, [initialConversationId, data]);
+    if (!initialConversationId) return;
+    if (!data) return;
+    if (!safe?.id) return;
+    openDrawer(safe.id);
+  }, [initialConversationId, data, safe?.id]);
 
   if (state === 'loading') return <SkeletonConversation />;
   if (state === 'error') return <InlineError message="Failed to load conversation." />;
@@ -61,7 +70,7 @@ export default function GuestExperience({ initialConversationId }: { initialConv
     );
   }
 
-  const relatedReservations = safe.related_reservations ?? [];
+  const relatedReservations = safeRelatedReservations(safe);
   const hasRelated = relatedReservations.length > 0;
 
   return (

--- a/app/go/c/[token]/route.ts
+++ b/app/go/c/[token]/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server.js';
+import { resolveConversationUuid } from '../../../../apps/shared/lib/conversationUuid.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CACHE_CONTROL = 'no-store';
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function canonicalConversationUrl(req: Request, uuid: string) {
+  const origin = new URL(req.url);
+  const dest = new URL('/dashboard/guest-experience/all', origin.origin);
+  dest.searchParams.set('conversation', uuid);
+  return dest.toString();
+}
+
+function notFoundHtml(token: string | null) {
+  const advice = token
+    ? `<p>The conversation link <code>${escapeHtml(token)}</code> could not be resolved. It may have expired, been deleted, or you might not have permission to view it.</p>`
+    : '<p>The conversation link could not be resolved. It may have expired, been deleted, or you might not have permission to view it.</p>';
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Conversation not found</title>
+    <style>
+      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 0; padding: 0; background: #f9fafb; color: #111827; }
+      main { max-width: 480px; margin: 40px auto; background: #fff; border-radius: 12px; padding: 32px; box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08); }
+      h1 { font-size: 1.5rem; margin-bottom: 16px; }
+      p { line-height: 1.6; margin: 12px 0; }
+      a { color: #2563eb; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      code { background: #f3f4f6; border-radius: 4px; padding: 2px 4px; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Conversation not found</h1>
+      ${advice}
+      <p><a href="/dashboard/guest-experience/all">Return to Guest Experience</a></p>
+    </main>
+  </body>
+</html>`;
+}
+
+function buildNotFoundResponse(token: string | null, includeBody: boolean) {
+  const headers = new Headers({ 'Cache-Control': CACHE_CONTROL });
+  if (includeBody) {
+    headers.set('Content-Type', 'text/html; charset=utf-8');
+    return new NextResponse(notFoundHtml(token), { status: 404, headers });
+  }
+  return new NextResponse(null, { status: 404, headers });
+}
+
+export async function resolveConversationToken(token: string | null | undefined) {
+  const raw = typeof token === 'string' ? token.trim() : '';
+  if (!raw) return null;
+  if (UUID_RE.test(raw)) {
+    return raw.toLowerCase();
+  }
+  try {
+    const uuid = await resolveConversationUuid(raw, {
+      allowMintFallback: false,
+      skipRedirectProbe: true,
+    });
+    if (uuid && UUID_RE.test(uuid)) {
+      return uuid.toLowerCase();
+    }
+  } catch {
+    // ignore resolver failures; fall through to return null
+  }
+  return null;
+}
+
+async function handleConversationRedirect(
+  req: Request,
+  token: string | null,
+  includeBody: boolean,
+) {
+  const resolved = await resolveConversationToken(token);
+  if (resolved) {
+    const location = canonicalConversationUrl(req, resolved);
+    const headers = new Headers({ 'Cache-Control': CACHE_CONTROL });
+    headers.set('Location', location);
+    return new NextResponse(null, { status: 302, headers });
+  }
+  return buildNotFoundResponse(token, includeBody);
+}
+
+export async function GET(req: Request, { params }: { params: { token?: string } }) {
+  return handleConversationRedirect(req, params?.token ?? null, true);
+}
+
+export async function HEAD(req: Request, { params }: { params: { token?: string } }) {
+  return handleConversationRedirect(req, params?.token ?? null, false);
+}
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;

--- a/app/inbox/conversations/[id]/page.tsx
+++ b/app/inbox/conversations/[id]/page.tsx
@@ -2,6 +2,6 @@ import { redirect } from 'next/navigation.js';
 
 // Redirect legacy /inbox/conversations/:id links to the dashboard deep link.
 export default function ConversationPage({ params }: { params: { id: string } }) {
-  const dest = `/dashboard/guest-experience/all?conversation=${encodeURIComponent(params.id)}`;
+  const dest = `/go/c/${encodeURIComponent(params.id)}`;
   redirect(dest);
 }

--- a/apps/shared/lib/links.ts
+++ b/apps/shared/lib/links.ts
@@ -16,10 +16,8 @@ const normalizeBaseUrl = (input?: string | URL): string => {
 export function makeConversationLink({ uuid, baseUrl }: ConversationLinkArgs) {
   const base = normalizeBaseUrl(baseUrl);
   if (uuid && UUID_RE.test(String(uuid))) {
-    // Deep-link to the All page instead of CS
-    return `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(
-      String(uuid).toLowerCase(),
-    )}`;
+    const normalized = String(uuid).toLowerCase();
+    return `${base}/go/c/${encodeURIComponent(normalized)}`;
   }
   return null;
 }

--- a/apps/shared/lib/verifyLink.ts
+++ b/apps/shared/lib/verifyLink.ts
@@ -9,7 +9,9 @@ export async function verifyConversationLink(url: string): Promise<boolean> {
     // Accept any 3xx; verify Location header points to our login or deep link path
     if (res.status >= 300 && res.status < 400) {
       const loc = res.headers.get('location') ?? '';
-      return /\/login\b|\/dashboard\/guest-experience\/all\b/.test(loc);
+      if (/\/login\b/.test(loc)) return true;
+      if (/\/go\/c\//.test(loc)) return true;
+      return /\/dashboard\/guest-experience\/all\b/.test(loc);
     }
     return false;
   } catch {

--- a/cron.mjs
+++ b/cron.mjs
@@ -33,10 +33,7 @@ export function buildSafeDeepLink(lookupId, uuid) {
     } catch {}
   }
   if (!raw) return `${base}/dashboard/guest-experience/all`;
-  if (/^\d+$/.test(raw)) {
-    return `${base}/dashboard/guest-experience/all?legacyId=${encodeURIComponent(raw)}`;
-  }
-  return `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(raw)}`;
+  return `${base}/go/c/${encodeURIComponent(raw)}`;
 }
 
 // ---------------------------

--- a/docs/adr/001-universal-conversation-link.md
+++ b/docs/adr/001-universal-conversation-link.md
@@ -1,0 +1,51 @@
+# ADR 001: Universal conversation deep link
+
+## Status
+
+Accepted – implemented in `fix/universal-conversation-deeplink`.
+
+## Context
+
+SLA alerts and a variety of legacy routes deep-linked agents straight to
+`/dashboard/guest-experience/all?conversation=<token>`. The token could be a
+UUID, a numeric legacy identifier, or a slug. On WebKit/Safari the guest
+experience page occasionally loaded before the conversation record resolved,
+triggering `TypeError: undefined is not an object (evaluating 's.related_reservations')`
+while the UI attempted to hydrate related reservations. We also saw alert emails
+break when a link pointed at an identifier that required a DB lookup because the
+SPA booted without the conversation list preloaded.
+
+## Decision
+
+* Introduced a universal redirect entry point at `/go/c/:token`.
+  * `:token` accepts UUIDs, numeric ids and slugs.
+  * The handler asks the hedged resolver for the canonical UUID (no mint
+    fallback). When successful it issues a `302` redirect to the canonical view
+    (`/dashboard/guest-experience/all?conversation=<uuid>`). When resolution
+    fails it serves a small HTML page explaining that the conversation could not
+    be found and links back to the guest experience dashboard.
+  * `resolveConversationToken` is exported for reuse in tests and helper
+    servers.
+* Hardened the guest experience client to tolerate undefined conversation data
+  by guarding related reservation access with optional chaining and a default
+  array before kicking off drawer side-effects.
+* Updated every link builder used by alerts and redirectors to emit
+  `https://app.boomnow.com/go/c/<token>` instead of the brittle query-string
+  form. Legacy routes (`/dashboard/guest-experience/all?conversation=...`) still
+  work for backwards compatibility, but new links all flow through the redirect
+  entry point.
+* Added Playwright coverage for `/go/c/<uuid>`, `/go/c/<legacy-id>`, and
+  `/go/c/<slug>` plus unit tests for the token resolver and the UI guard.
+
+## Consequences
+
+* Alert emails and cron notifications now produce stable conversation links that
+  Safari can open reliably. The guard ensures the guest experience surface never
+  dereferences `related_reservations` before data arrives.
+* The redirector and cron scripts rely on the shared `makeConversationLink`
+  helper, so any future identifier paths will naturally adopt the universal
+  route.
+* Environment expectations remain unchanged: the resolver still honours
+  `RESOLVE_SECRET`, `RESOLVE_BASE_URL`, `APP_URL`, and associated hedging
+  settings. Operators need no additional configuration beyond ensuring the
+  existing resolver credentials work in the `/go/c/:token` handler.

--- a/lib/alertLink.js
+++ b/lib/alertLink.js
@@ -1,4 +1,4 @@
-import { appUrl } from './links.js';
+import { appUrl, makeConversationLink } from './links.js';
 import { makeLinkToken } from './linkToken.js';
 import { mintUuidFromRaw } from '../apps/shared/lib/canonicalConversationUuid.js';
 import { resolveViaInternalEndpointWithDetails } from './internalResolve.js';
@@ -64,6 +64,16 @@ async function getResolveConversationUuid() {
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+const UNIVERSAL_ROUTE_RE = /\/go\/c\//;
+const DASHBOARD_ROUTE_RE = /\/dashboard\/guest-experience\/all\b/;
+
+function isConversationLocation(loc) {
+  if (!loc) return false;
+  if (UNIVERSAL_ROUTE_RE.test(loc)) return true;
+  if (DASHBOARD_ROUTE_RE.test(loc) && /[?&]conversation=/.test(loc)) return true;
+  return false;
+}
+
 async function defaultVerify(url) {
   try {
     const u = new URL(url);
@@ -73,7 +83,7 @@ async function defaultVerify(url) {
     if (isToken) {
       if (res.status >= 300 && res.status < 400) {
         const loc = res.headers.get('location') || '';
-        return /\/dashboard\/guest-experience\/all\b/.test(loc) && /[?&]conversation=/.test(loc);
+        return isConversationLocation(loc);
       }
       return false;
     }
@@ -81,7 +91,8 @@ async function defaultVerify(url) {
     if (res.status === 200) return true;
     if (res.status >= 300 && res.status < 400) {
       const loc = res.headers.get('location') || '';
-      return /\/login\b|\/dashboard\/guest-experience\/all\b/.test(loc);
+      if (/\/login\b/.test(loc)) return true;
+      return isConversationLocation(loc);
     }
     if ([401, 403, 406].includes(res.status)) return true;
     return false;
@@ -201,7 +212,9 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
       }
     }
 
-    const deep = `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`;
+    const deep =
+      makeConversationLink({ uuid, baseUrl: base }) ||
+      `${base}/go/c/${encodeURIComponent(uuid)}`;
     backupUrl = deep;
 
     if (mintedFallback) {
@@ -215,9 +228,9 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
       }
       if (!mintedUuid) return null;
       const canonicalUuid = mintedUuid.toLowerCase();
-      const mintedDeep = `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(
-        canonicalUuid
-      )}`;
+      const mintedDeep =
+        makeConversationLink({ uuid: canonicalUuid, baseUrl: base }) ||
+        `${base}/go/c/${encodeURIComponent(canonicalUuid)}`;
       const ok = await verify(mintedDeep);
       if (!ok) return null;
       uuid = canonicalUuid;
@@ -262,15 +275,7 @@ export async function buildUniversalConversationLink(input = {}, opts = {}) {
       return null;
     }
     // Non-strict mode: keep the old legacy dashboard links behavior.
-    if (/^[0-9]+$/.test(fallbackRaw)) {
-      url = `${base}/dashboard/guest-experience/all?legacyId=${encodeURIComponent(
-        fallbackRaw
-      )}`;
-    } else {
-      url = `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(
-        fallbackRaw
-      )}`;
-    }
+    url = `${base}/go/c/${encodeURIComponent(fallbackRaw)}`;
     kind = 'legacy';
     backupUrl = url;
   }

--- a/lib/conversationResolveCore.js
+++ b/lib/conversationResolveCore.js
@@ -99,18 +99,14 @@ export function conversationDeepLink(uuid, base) {
   if (!normalizedUuid || !isUuid(normalizedUuid)) {
     throw new Error('conversationDeepLink: uuid required');
   }
-  const path = `/dashboard/guest-experience/all?conversation=${encodeURIComponent(
-    normalizedUuid.toLowerCase(),
-  )}`;
+  const lowerUuid = normalizedUuid.toLowerCase();
+  const path = `/go/c/${encodeURIComponent(lowerUuid)}`;
   if (!base) return path;
   const trimmedBase = normalizeIdentifier(base).replace(/\/+$/, '');
   if (!trimmedBase) return path;
   try {
-    const url = new URL(trimmedBase);
-    const pathname = url.pathname.replace(/\/+$/, '');
-    const [targetPath, targetQuery] = path.split('?');
-    url.pathname = `${pathname}${targetPath}`;
-    url.search = targetQuery ? `?${targetQuery}` : '';
+    const url = new URL(path, `${trimmedBase}/`);
+    url.search = '';
     url.hash = '';
     return url.toString();
   } catch {

--- a/lib/links.js
+++ b/lib/links.js
@@ -16,10 +16,8 @@ const normalizeBaseUrl = (input) => {
 export function makeConversationLink({ uuid, baseUrl }) {
   const base = normalizeBaseUrl(baseUrl)
   if (uuid && UUID_RE.test(String(uuid))) {
-    // Deep-link to the All page instead of CS
-    return `${base}/dashboard/guest-experience/all?conversation=${encodeURIComponent(
-      String(uuid).toLowerCase(),
-    )}`
+    const normalized = String(uuid).toLowerCase()
+    return `${base}/go/c/${encodeURIComponent(normalized)}`
   }
   return null
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,9 +3,8 @@ import { NextResponse } from 'next/server.js';
 
 function redirectToConversation(url: URL, conversation: string) {
   const dest = new URL(url);
-  dest.pathname = '/dashboard/guest-experience/all';
+  dest.pathname = `/go/c/${encodeURIComponent(conversation)}`;
   dest.searchParams.delete('cid');
-  dest.searchParams.set('conversation', conversation);
   return NextResponse.redirect(dest, { status: 308 });
 }
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "@vitalets/google-translate-api": "^8.0.0",
     "@hono/node-server": "^1.11.1",
+    "@vitalets/google-translate-api": "^8.0.0",
     "axios": "^1.6.8",
     "cockatiel": "^2.0.2",
     "hono": "^4.6.6",

--- a/packages/linking/src/deeplink.js
+++ b/packages/linking/src/deeplink.js
@@ -1,5 +1,4 @@
-const UUID_PATH = '/dashboard/guest-experience/all';
-const LEGACY_PATH = '/dashboard/guest-experience/all';
+const UNIVERSAL_PREFIX = '/go/c/';
 
 function cleanBase(url) {
   const raw = String(url || '').trim();
@@ -10,14 +9,19 @@ function cleanBase(url) {
 export function buildCanonicalDeepLink(input = {}) {
   const base = cleanBase(input.appUrl);
   if (input.uuid) {
-    const url = new URL(UUID_PATH, base + '/');
-    url.searchParams.set('conversation', String(input.uuid));
-    return url.toString();
+    const token = String(input.uuid).trim().toLowerCase();
+    if (!token) throw new Error('identifier_required');
+    return `${base}${UNIVERSAL_PREFIX}${encodeURIComponent(token)}`;
   }
   if (input.legacyId != null) {
-    const url = new URL(LEGACY_PATH, base + '/');
-    url.searchParams.set('legacyId', String(input.legacyId));
-    return url.toString();
+    const token = String(input.legacyId).trim();
+    if (!token) throw new Error('identifier_required');
+    return `${base}${UNIVERSAL_PREFIX}${encodeURIComponent(token)}`;
   }
-  throw new Error('uuid_or_legacyId_required');
+  if (input.slug) {
+    const token = String(input.slug).trim();
+    if (!token) throw new Error('identifier_required');
+    return `${base}${UNIVERSAL_PREFIX}${encodeURIComponent(token)}`;
+  }
+  throw new Error('identifier_required');
 }

--- a/tests/alert-conversation-link.spec.ts
+++ b/tests/alert-conversation-link.spec.ts
@@ -61,9 +61,7 @@ test('ensureAlertConversationLink mints uuid for numeric identifier when resolve
   expect(link?.uuid).toBe(expected);
   expect(link?.kind).toBe('deep-link');
   expect(link?.minted).toBe(true);
-  expect(link?.url).toBe(
-    `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(expected)}`
-  );
+  expect(link?.url).toBe(`${BASE}/go/c/${encodeURIComponent(expected)}`);
 });
 
 test('ensureAlertConversationLink extracts slug from inline thread and mints when needed', async () => {
@@ -71,7 +69,7 @@ test('ensureAlertConversationLink extracts slug from inline thread and mints whe
   const inlineThread = {
     messages: [
       { conversation_slug: 'inline-slug' },
-      { body: 'see https://app.example.com/dashboard/guest-experience/all?conversation=ignored' },
+      { body: 'see https://app.example.com/go/c/ignored' },
     ],
   };
   const link = await ensureAlertConversationLink(
@@ -87,9 +85,7 @@ test('ensureAlertConversationLink extracts slug from inline thread and mints whe
   expect(link?.uuid).toBe(expected);
   expect(link?.kind).toBe('deep-link');
   expect(link?.minted).toBe(true);
-  expect(link?.url).toBe(
-    `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(expected)}`
-  );
+  expect(link?.url).toBe(`${BASE}/go/c/${encodeURIComponent(expected)}`);
 });
 
 test('ensureAlertConversationLink prefers resolver-supplied uuid', async () => {

--- a/tests/alert-link.spec.ts
+++ b/tests/alert-link.spec.ts
@@ -118,7 +118,7 @@ test('buildUniversalConversationLink returns token link for uuid', async () => {
 
 test('buildUniversalConversationLink degrades to deep link when token verification fails', async () => {
   const calls: string[] = [];
-  const deep = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`;
+  const deep = `${BASE}/go/c/${encodeURIComponent(uuid)}`;
   const res = await buildUniversalConversationLink(
     { uuid },
     {
@@ -149,7 +149,7 @@ test('buildUniversalConversationLink falls back to deep link when token mint fai
       verify: async (url) => {
         calls.push(url);
         expect(url).toBe(
-          `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`
+          `${BASE}/go/c/${encodeURIComponent(uuid)}`
         );
         return true;
       },
@@ -160,7 +160,7 @@ test('buildUniversalConversationLink falls back to deep link when token mint fai
   );
   expect(res?.kind).toBe('deep-link');
   expect(res?.url).toBe(
-    `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`
+    `${BASE}/go/c/${encodeURIComponent(uuid)}`
   );
   expect(calls.length).toBeGreaterThanOrEqual(2);
 });
@@ -172,7 +172,7 @@ test('buildUniversalConversationLink mints fallback uuid when strict mode enable
     { baseUrl: BASE, verify: async () => true, strictUuid: true }
   );
   const minted = mintUuidFromRaw(slug);
-  const expected = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(minted)}`;
+  const expected = `${BASE}/go/c/${encodeURIComponent(minted)}`;
   expect(res?.kind).toBe('deep-link');
   expect(res?.minted).toBe(true);
   expect(res?.url).toBe(expected);
@@ -187,7 +187,7 @@ test('buildUniversalConversationLink uses resolver(s) to obtain uuid; mints when
     { baseUrl: BASE, verify: async () => true, strictUuid: true }
   );
   const minted = mintUuidFromRaw(String(legacyId));
-  const expected = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(minted)}`;
+  const expected = `${BASE}/go/c/${encodeURIComponent(minted)}`;
   expect(res?.kind).toBe('deep-link');
   expect(res?.minted).toBe(true);
   expect(res?.url).toBe(expected);
@@ -263,7 +263,7 @@ test('buildUniversalConversationLink uses resolver link when resolver mints uuid
       },
     }
   );
-  const expected = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`;
+  const expected = `${BASE}/go/c/${encodeURIComponent(uuid)}`;
   expect(res?.kind).toBe('deep-link');
   expect(res?.minted).toBe(true);
   expect(res?.url).toBe(expected);
@@ -286,7 +286,7 @@ test('buildUniversalConversationLink uses resolver link when resolver mints uuid
       },
     }
   );
-  const expected = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`;
+  const expected = `${BASE}/go/c/${encodeURIComponent(uuid)}`;
   expect(res?.kind).toBe('deep-link');
   expect(res?.minted).toBe(true);
   expect(res?.url).toBe(expected);
@@ -310,7 +310,7 @@ test('buildUniversalConversationLink detects minted fallback without resolver de
       },
     }
   );
-  const expected = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(minted)}`;
+  const expected = `${BASE}/go/c/${encodeURIComponent(minted)}`;
   expect(res?.kind).toBe('deep-link');
   expect(res?.minted).toBe(true);
   expect(res?.url).toBe(expected);
@@ -382,7 +382,7 @@ test('buildUniversalConversationLink verifies resolver link when resolver indica
     return { ok: true, json: async () => ({}) } as any;
   };
   const legacyId = '12345';
-  const expected = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`;
+  const expected = `${BASE}/go/c/${encodeURIComponent(uuid)}`;
   const res = await buildUniversalConversationLink(
     { uuid, legacyId },
     {
@@ -412,7 +412,7 @@ test('buildUniversalConversationLink falls back to deep link when token verifica
     }
   );
   expect(res?.kind).toBe('deep-link');
-  expect(res?.url).toBe(`${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`);
+  expect(res?.url).toBe(`${BASE}/go/c/${encodeURIComponent(uuid)}`);
 });
 
 test('buildUniversalConversationLink uses resolver link for minted identifiers even when strict mode disabled', async () => {
@@ -432,7 +432,7 @@ test('buildUniversalConversationLink uses resolver link for minted identifiers e
       },
     }
   );
-  const expected = `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`;
+  const expected = `${BASE}/go/c/${encodeURIComponent(uuid)}`;
   expect(res?.kind).toBe('deep-link');
   expect(res?.minted).toBe(true);
   expect(res?.url).toBe(expected);

--- a/tests/app-url-sanitize.spec.ts
+++ b/tests/app-url-sanitize.spec.ts
@@ -16,12 +16,10 @@ test('APP_URL with CR/LF produces clean, single-line links', async () => {
   expect(appUrl()).toBe('https://app.boomnow.com');
   const uuid = '123e4567-e89b-12d3-a456-426614174000';
   const deep = makeConversationLink({ uuid });
-  expect(deep).toBe('https://app.boomnow.com/dashboard/guest-experience/all?conversation=123e4567-e89b-12d3-a456-426614174000');
+  expect(deep).toBe('https://app.boomnow.com/go/c/123e4567-e89b-12d3-a456-426614174000');
   const fallback = buildSafeDeepLink('991130', null);
   const minted = mintUuidFromRaw('991130');
-  expect(fallback).toBe(
-    `https://app.boomnow.com/dashboard/guest-experience/all?conversation=${minted}`,
-  );
+  expect(fallback).toBe(`https://app.boomnow.com/go/c/${minted}`);
 
   if (OLD !== undefined) process.env.APP_URL = OLD; else delete process.env.APP_URL;
 });

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -10,7 +10,7 @@ test('GET /inbox/conversations/123 -> 308 cs deep link', async () => {
   const res = await middleware(req);
   expect(res.status).toBe(308);
   expect(res.headers.get('location')).toBe(
-    'https://app.boomnow.com/dashboard/guest-experience/all?conversation=123'
+    'https://app.boomnow.com/go/c/123'
   );
 });
 
@@ -21,7 +21,7 @@ test('GET /inbox/conversations/123?cid=456 keeps extras but drops cid', async ()
   const res = await middleware(req);
   expect(res.status).toBe(308);
   expect(res.headers.get('location')).toBe(
-    'https://app.boomnow.com/dashboard/guest-experience/all?foo=bar&conversation=123'
+    'https://app.boomnow.com/go/c/123?foo=bar'
   );
 });
 
@@ -30,7 +30,7 @@ test('middleware redirects legacy /inbox?cid=uuid to /c', async () => {
   const res = await middleware(req);
   expect(res.status).toBe(308);
   expect(res.headers.get('location')).toBe(
-    `https://app.boomnow.com/dashboard/guest-experience/all?conversation=${uuid}`
+    `https://app.boomnow.com/go/c/${uuid}`
   );
 });
 
@@ -39,12 +39,12 @@ test('middleware retains extra params when redirecting legacy inbox', async () =
   const res = await middleware(req);
   expect(res.status).toBe(308);
   expect(res.headers.get('location')).toBe(
-    `https://app.boomnow.com/dashboard/guest-experience/all?foo=bar&conversation=${uuid}`
+    `https://app.boomnow.com/go/c/${uuid}?foo=bar`
   );
 });
 
 test('POST /api/login with next=dashboard link -> 303 to that path', async () => {
-  const next = `/dashboard/guest-experience/all?conversation=${uuid}`;
+  const next = `/go/c/${uuid}`;
   const body = new URLSearchParams({
     email: 'test@example.com',
     password: 'x',

--- a/tests/conversation-link.spec.ts
+++ b/tests/conversation-link.spec.ts
@@ -52,14 +52,14 @@ test.afterEach(() => {
 
 test('makeConversationLink builds ?conversation when uuid provided', () => {
   expect(makeConversationLink({ uuid })).toBe(
-    `${BASE}/dashboard/guest-experience/all?conversation=${encodeURIComponent(uuid)}`
+    `${BASE}/go/c/${encodeURIComponent(uuid)}`
   );
 });
 
 test('makeConversationLink accepts baseUrl override', () => {
   expect(
     makeConversationLink({ uuid, baseUrl: 'http://localhost:4321' })
-  ).toBe(`http://localhost:4321/dashboard/guest-experience/all?conversation=${uuid}`);
+  ).toBe(`http://localhost:4321/go/c/${uuid}`);
 });
 
 test('makeConversationLink returns null when uuid missing', () => {
@@ -82,7 +82,7 @@ test('buildAlertConversationLink produces verified link with id display', async 
     { conversation_uuid: uuid },
     { baseUrl: BASE, verify: async () => true, strictUuid: true }
   );
-  expect(built?.url).toMatch(/\/r\/(t|conversation)\/|conversation=/);
+  expect(built?.url).toMatch(/\/r\/(t|conversation)\/|\/go\/c\//);
   expect(built?.idDisplay).toBe(uuid.toLowerCase());
 });
 
@@ -130,7 +130,7 @@ test('mailer uses uuid when available', async () => {
         res.payload?.conversation === uuid || res.payload?.uuid === uuid
       );
     }
-    if (url.includes('/dashboard/guest-experience/')) {
+    if (url.includes('/go/c/')) {
       return true;
     }
     return false;
@@ -183,7 +183,7 @@ test('mailer resolves legacyId via internal endpoint and emits token link', asyn
         decoded.payload?.conversation === uuid || decoded.payload?.uuid === uuid
       );
     }
-    if (url.includes('/dashboard/guest-experience/')) {
+    if (url.includes('/go/c/')) {
       return true;
     }
     return false;
@@ -228,7 +228,7 @@ test('mailer mints uuid when canonical mapping missing (strict mode)', async () 
   }
   expect(emails.length).toBe(1);
   const minted = mintUuidFromRaw('789');
-  expect(emails[0].html).toContain(`/c/${encodeURIComponent(minted ?? '')}`);
+  expect(emails[0].html).toContain(`/go/c/${encodeURIComponent(minted ?? '')}`);
   expect(metricsArr).toContain('alerts.sent_with_minted_link');
 });
 
@@ -257,6 +257,6 @@ test('mailer mints uuid for slug when resolver unavailable', async () => {
   }
   expect(emails.length).toBe(1);
   const minted = mintUuidFromRaw(slug);
-  expect(emails[0].html).toContain(`/c/${encodeURIComponent(minted ?? '')}`);
+  expect(emails[0].html).toContain(`/go/c/${encodeURIComponent(minted ?? '')}`);
   expect(metricsArr).toContain('alerts.sent_with_minted_link');
 });

--- a/tests/conversation-redirect.spec.ts
+++ b/tests/conversation-redirect.spec.ts
@@ -26,7 +26,7 @@ test('conversation redirect resolves known slug to deep link', async () => {
   } catch (err) {
     location = extractRedirect(err);
   }
-  expect(location).toBe(`http://test/dashboard/guest-experience/all?conversation=${uuid}`);
+  expect(location).toBe(`http://test/go/c/${uuid}`);
 });
 
 test('conversation redirect mints uuid when slug unknown', async () => {
@@ -36,6 +36,5 @@ test('conversation redirect mints uuid when slug unknown', async () => {
   } catch (err) {
     location = extractRedirect(err);
   }
-  expect(location).toMatch(/conversation=/);
-  expect(location).toMatch(/^http:\/\/test\/dashboard\/guest-experience\/all\?conversation=/);
+  expect(location).toMatch(/^http:\/\/test\/go\/c\//);
 });

--- a/tests/conversation-resolve-core.spec.ts
+++ b/tests/conversation-resolve-core.spec.ts
@@ -66,6 +66,6 @@ test('resolveConversationUuid returns null for empty input', async () => {
 test('conversationDeepLink builds absolute deep link with base', () => {
   const uuid = '123e4567-e89b-12d3-a456-426614174000';
   const link = conversationDeepLink(uuid, 'https://app.example.com');
-  expect(link).toBe(`https://app.example.com/dashboard/guest-experience/all?conversation=${uuid}`);
+  expect(link).toBe(`https://app.example.com/go/c/${uuid}`);
 });
 

--- a/tests/cron-fallback-link.spec.ts
+++ b/tests/cron-fallback-link.spec.ts
@@ -7,7 +7,7 @@ test('cron fallback builds shortlinks when UUID is unavailable', async () => {
   delete (globalThis as any).__CRON_TEST__;
   const { buildSafeDeepLink } = mod as any;
   const a = buildSafeDeepLink('991130', null);
-  expect(a).toMatch(/dashboard\/guest-experience\/all\?conversation=/);
+  expect(a).toMatch(/\/go\/c\//);
   const b = buildSafeDeepLink('abc-slug', null);
-  expect(b).toMatch(/dashboard\/guest-experience\/all\?conversation=/);
+  expect(b).toMatch(/\/go\/c\//);
 });

--- a/tests/deep-link.spec.ts
+++ b/tests/deep-link.spec.ts
@@ -6,13 +6,14 @@ import { startTestServer, stopTestServer } from './helpers/nextServer';
 test('deep-link to conversation loads without runtime errors', async ({ page }) => {
   const { server, port } = await startTestServer();
   const id = 'test-123';
-  await page.goto(`http://localhost:${port}/dashboard/guest-experience/all?conversation=${id}`);
+  await page.goto(`http://localhost:${port}/go/c/${id}`);
 
   // No fatal overlay/dialog appears
   const errorDialog = page.getByText(/TypeError: undefined is not an object/);
   await expect(errorDialog).toHaveCount(0);
 
-  // Page reaches a stable, interactive state
-  await expect(page).toHaveURL(/\/dashboard\/guest-experience\/all/);
+  // Unknown conversations render a friendly not-found page without crashing
+  await expect(page).toHaveURL(new RegExp(`/go/c/${id}$`));
+  await expect(page.getByRole('heading', { name: /conversation not found/i })).toBeVisible();
   await stopTestServer(server);
 });

--- a/tests/go-conversation-route.spec.ts
+++ b/tests/go-conversation-route.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { resolveConversationToken } from '../app/go/c/[token]/route';
+import { prisma } from '../lib/db';
+
+const DIRECT_UUID = '01890b14-b4cd-7eef-b13e-bb8c083bad70';
+const LEGACY_ID = 445566;
+const LEGACY_UUID = '01890b14-b4cd-7eef-b13e-bb8c083bad71';
+const SLUG = 'suite-guest-checkin';
+const SLUG_UUID = '01890b14-b4cd-7eef-b13e-bb8c083bad72';
+
+test.beforeEach(() => {
+  prisma.conversation._data.clear();
+  prisma.conversation_aliases._data.clear();
+});
+
+test('resolveConversationToken returns uuid as-is when provided', async () => {
+  await expect(resolveConversationToken(DIRECT_UUID)).resolves.toBe(DIRECT_UUID.toLowerCase());
+});
+
+test('resolveConversationToken looks up legacy ids in prisma conversation store', async () => {
+  prisma.conversation._data.set(LEGACY_ID, { uuid: LEGACY_UUID, legacyId: LEGACY_ID });
+  await expect(resolveConversationToken(String(LEGACY_ID))).resolves.toBe(LEGACY_UUID.toLowerCase());
+});
+
+test('resolveConversationToken resolves slugs to their canonical uuid', async () => {
+  prisma.conversation._data.set(LEGACY_ID + 1, { uuid: SLUG_UUID, slug: SLUG });
+  await expect(resolveConversationToken(SLUG)).resolves.toBe(SLUG_UUID.toLowerCase());
+});
+
+test('resolveConversationToken returns null when lookup fails', async () => {
+  await expect(resolveConversationToken('missing-conversation')).resolves.toBeNull();
+});

--- a/tests/guest-experience-guard.spec.tsx
+++ b/tests/guest-experience-guard.spec.tsx
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+import { safeRelatedReservations } from '../app/dashboard/guest-experience/all/GuestExperience';
+
+// Ensure guard returns an empty list when conversation data is missing.
+test('safeRelatedReservations handles undefined conversation data', () => {
+  expect(safeRelatedReservations(undefined)).toEqual([]);
+  expect(safeRelatedReservations(null)).toEqual([]);
+  expect(safeRelatedReservations({ related_reservations: undefined } as any)).toEqual([]);
+});
+
+// And when data exists, the helper surfaces it untouched.
+test('safeRelatedReservations preserves related reservations', () => {
+  const reservations = [{ id: 'r1' }, { id: 'r2' }];
+  expect(safeRelatedReservations({ related_reservations: reservations } as any)).toBe(reservations);
+});

--- a/tests/legacy-redirect-db-error.spec.ts
+++ b/tests/legacy-redirect-db-error.spec.ts
@@ -32,7 +32,7 @@ test('legacy redirect returns 302 even if DB throws', async () => {
     } catch (err) {
       location = extractRedirect(err);
     }
-    expect(location).toMatch(/conversation=/);
+    expect(location).toMatch(/\/go\/c\//);
   } finally {
     prisma.conversation.findFirst = originalFindFirst;
   }

--- a/tests/legacy-redirect.spec.ts
+++ b/tests/legacy-redirect.spec.ts
@@ -27,7 +27,7 @@ test('legacy redirect resolves to uuid deep link', async () => {
   } catch (err) {
     location = extractRedirect(err)
   }
-  expect(location).toBe(`http://test/dashboard/guest-experience/all?conversation=${uuid}`)
+  expect(location).toBe(`http://test/go/c/${uuid}`)
 })
 
 test('legacy redirect mints deterministic uuid when mapping missing', async () => {
@@ -37,8 +37,7 @@ test('legacy redirect mints deterministic uuid when mapping missing', async () =
   } catch (err) {
     location = extractRedirect(err)
   }
-  expect(location).toMatch(/conversation=/)
-  expect(location).toMatch(/^http:\/\/test\/dashboard\/guest-experience\/all\?conversation=/)
+  expect(location).toMatch(/^http:\/\/test\/go\/c\//)
 })
 
 test('legacy redirect resolves via alias when conversation missing', async () => {
@@ -59,7 +58,7 @@ test('legacy redirect resolves via alias when conversation missing', async () =>
     location = extractRedirect(err)
   }
 
-  expect(location).toBe(`http://test/dashboard/guest-experience/all?conversation=${uuid}`)
+  expect(location).toBe(`http://test/go/c/${uuid}`)
 
   prisma.conversation_aliases._data.delete(legacyId)
 })

--- a/tests/linking-deeplink.spec.ts
+++ b/tests/linking-deeplink.spec.ts
@@ -3,14 +3,21 @@ import { buildCanonicalDeepLink } from '../packages/linking/src/deeplink.js';
 
 test('buildCanonicalDeepLink prefers uuid route', () => {
   const url = buildCanonicalDeepLink({ appUrl: 'https://app.example.com', uuid: 'abc' });
-  expect(url).toBe('https://app.example.com/dashboard/guest-experience/all?conversation=abc');
+  expect(url).toBe('https://app.example.com/go/c/abc');
 });
 
 test('buildCanonicalDeepLink falls back to legacy id', () => {
   const url = buildCanonicalDeepLink({ appUrl: 'https://app.example.com/', legacyId: 42 });
-  expect(url).toBe('https://app.example.com/dashboard/guest-experience/all?legacyId=42');
+  expect(url).toBe('https://app.example.com/go/c/42');
+});
+
+test('buildCanonicalDeepLink supports slug tokens', () => {
+  const url = buildCanonicalDeepLink({ appUrl: 'https://app.example.com', slug: 'welcome-guests' });
+  expect(url).toBe('https://app.example.com/go/c/welcome-guests');
 });
 
 test('buildCanonicalDeepLink throws without identifier', () => {
-  expect(() => buildCanonicalDeepLink({ appUrl: 'https://app.example.com' })).toThrow();
+  expect(() => buildCanonicalDeepLink({ appUrl: 'https://app.example.com' })).toThrow(
+    'identifier_required'
+  );
 });

--- a/tests/redirector.spec.ts
+++ b/tests/redirector.spec.ts
@@ -63,7 +63,7 @@ test('GET /u/:token with expired JWT redirects to legacy fallback', async () => 
   const res = await app.fetch(new Request(`http://redirect.example/u/${token}`, { method: 'GET' }));
   expect(res.status).toBe(303);
   expect(res.headers.get('location')).toBe(
-    'https://app.example.com/dashboard/guest-experience/all?legacyId=1010993'
+    'https://app.example.com/go/c/1010993'
   );
 });
 

--- a/tests/resolve-uuid-ts-bridge.spec.ts
+++ b/tests/resolve-uuid-ts-bridge.spec.ts
@@ -10,7 +10,7 @@ test('TS conversations.ts re-exports robust JS implementation (redirect-probe wo
     global.fetch = (async () =>
       ({
         headers: new Map([
-          ['location', `https://app.boomnow.com/dashboard/guest-experience/all?conversation=${UUID}`],
+          ['location', `https://app.boomnow.com/go/c/${UUID}`],
         ]),
         text: async () => '',
       } as any)) as any;

--- a/tests/resolve-uuid.redirect.spec.js
+++ b/tests/resolve-uuid.redirect.spec.js
@@ -9,7 +9,7 @@ test('redirect-probe: 302 Location header', async () => {
   global.fetch = async (_u, _o) => ({
     headers: new Map([[
       'location',
-      'https://app.boomnow.com/dashboard/guest-experience/all?conversation=123e4567-e89b-12d3-a456-426614174000'
+      'https://app.boomnow.com/go/c/123e4567-e89b-12d3-a456-426614174000'
     ]]),
     text: async () => '',
   });
@@ -26,7 +26,7 @@ test('redirect-probe: 200 meta-refresh body', async () => {
     }
     return {
       headers: new Map(),
-      text: async () => '<meta http-equiv="refresh" content="0; url=/dashboard/guest-experience/all?conversation=123e4567-e89b-12d3-a456-426614174000">',
+      text: async () => '<meta http-equiv="refresh" content="0; url=/go/c/123e4567-e89b-12d3-a456-426614174000">',
     };
   };
   const got = await tryResolveConversationUuid('991130', {});
@@ -42,7 +42,7 @@ test('redirect-probe: 200 location.replace body', async () => {
     }
     return {
       headers: new Map(),
-      text: async () => '<script>location.replace("https://app.boomnow.com/dashboard/guest-experience/all?conversation=123e4567-e89b-12d3-a456-426614174000")</script>',
+      text: async () => '<script>location.replace("https://app.boomnow.com/go/c/123e4567-e89b-12d3-a456-426614174000")</script>',
     };
   };
   const got = await tryResolveConversationUuid('991130', {});

--- a/tests/resolve-uuid.spec.js
+++ b/tests/resolve-uuid.spec.js
@@ -31,7 +31,7 @@ async function withAlias(
 test('mines uuid from inlineThread messages (body contains deep link)', async () => {
   const uuid = '123e4567-e89b-12d3-a456-426614174000';
   const inlineThread = {
-    messages: [{ body: `see https://app.boomnow.com/dashboard/guest-experience/all?conversation=${uuid}` }],
+    messages: [{ body: `see https://app.boomnow.com/go/c/${uuid}` }],
   };
   const got = await tryResolveConversationUuid('991130', { inlineThread });
   expect(got).toBe(uuid);

--- a/tests/verify-link-redirects.spec.ts
+++ b/tests/verify-link-redirects.spec.ts
@@ -36,7 +36,7 @@ test('verifyConversationLink accepts 303/307/308 to login or deep link', async (
 
     global.fetch = fake(
       307,
-      'https://app.boomnow.com/dashboard/guest-experience/all?conversation=123e4567-e89b-12d3-a456-426614174000',
+      'https://app.boomnow.com/go/c/123e4567-e89b-12d3-a456-426614174000',
     );
     await expect(verifyConversationLink('https://example.com/x')).resolves.toBe(true);
 


### PR DESCRIPTION
## Summary
- add a universal `/go/c/:token` redirect that resolves uuids, legacy ids, or slugs and falls back to a not-found page when lookups miss
- harden the guest experience view with null-safe related reservation access and cover it with unit and e2e tests
- switch cron/alert link builders to emit `/go/c/` URLs and document the new deep link entry point

## Before
- SLA emails and legacy deep links depended on `/dashboard/guest-experience/all?conversation=…` and could crash Safari when data lagged

## After
- alerts, redirectors, and deep link helpers target `/go/c/<token>` which resolves to canonical conversations or a friendly not-found view, and the UI tolerates missing data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cff7cc5f24832abf3dfaa2040d1f62