### PR TITLE
fix(alerts): always emit canonical deep links; mint UUID fallback

### DIFF
--- a/tests/app-url-sanitize.spec.ts
+++ b/tests/app-url-sanitize.spec.ts
@@ -19,7 +19,9 @@ test('APP_URL with CR/LF produces clean, single-line links', async () => {
   expect(deep).toBe('https://app.boomnow.com/go/c/123e4567-e89b-12d3-a456-426614174000');
   const fallback = buildSafeDeepLink('991130', null);
   const minted = mintUuidFromRaw('991130');
-  expect(fallback).toBe(`https://app.boomnow.com/go/c/${minted}`);
+  expect(fallback).toBe(
+    `https://app.boomnow.com/dashboard/guest-experience/all?conversation=${minted}`
+  );
 
   if (OLD !== undefined) process.env.APP_URL = OLD; else delete process.env.APP_URL;
 });

--- a/tests/cron-fallback-link.spec.ts
+++ b/tests/cron-fallback-link.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { mintUuidFromRaw } from '../apps/shared/lib/canonicalConversationUuid.js';
 
 test('cron fallback builds shortlinks when UUID is unavailable', async () => {
   process.env.RESOLVE_SECRET = process.env.RESOLVE_SECRET || 'secret';
@@ -7,7 +8,19 @@ test('cron fallback builds shortlinks when UUID is unavailable', async () => {
   delete (globalThis as any).__CRON_TEST__;
   const { buildSafeDeepLink } = mod as any;
   const a = buildSafeDeepLink('991130', null);
-  expect(a).toMatch(/\/go\/c\//);
+  const mintedNumeric = mintUuidFromRaw('991130');
+  expect(a).toBe(
+    `https://app.boomnow.com/dashboard/guest-experience/all?conversation=${encodeURIComponent(mintedNumeric)}`
+  );
+  const numericParam = new URL(a).searchParams.get('conversation');
+  expect(numericParam).toBe(mintedNumeric);
+  expect(numericParam && /^\d+$/.test(numericParam)).toBe(false);
+
   const b = buildSafeDeepLink('abc-slug', null);
-  expect(b).toMatch(/\/go\/c\//);
+  const mintedSlug = mintUuidFromRaw('abc-slug');
+  expect(b).toBe(
+    `https://app.boomnow.com/dashboard/guest-experience/all?conversation=${encodeURIComponent(mintedSlug)}`
+  );
+  const slugParam = new URL(b).searchParams.get('conversation');
+  expect(slugParam).toBe(mintedSlug);
 });


### PR DESCRIPTION
## Summary
- update the cron alert flow to build canonical deep links via buildUniversalConversationLink and log when minted UUID fallbacks are used
- emit the same canonical link in alert emails and adjust the safe deep-link helper to mint deterministic UUIDs for legacy identifiers
- tighten cron unit tests to assert that numeric inputs mint UUID conversation parameters and that APP_URL sanitation preserves the canonical format

## Testing
- npm test *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0382bc5d8832a8c92840d0240e301