### PR TITLE
Guard guest experience against non-object conversations

### DIFF
--- a/app/dashboard/guest-experience/all/GuestExperience.tsx
+++ b/app/dashboard/guest-experience/all/GuestExperience.tsx
@@ -33,8 +33,12 @@ export function conversationViewState(args: {
 }
 
 export function safeRelatedReservations(conversation?: Conversation | null) {
-  const related = conversation?.related_reservations;
-  return Array.isArray(related) ? related : [];
+  if (!conversation || typeof conversation !== 'object') {
+    return [];
+  }
+
+  const related = (conversation as { related_reservations?: unknown }).related_reservations;
+  return Array.isArray(related) ? (related as Conversation['related_reservations']) : [];
 }
 
 export default function GuestExperience({ initialConversationId }: { initialConversationId?: string }) {

--- a/tests/guest-experience-guard.spec.tsx
+++ b/tests/guest-experience-guard.spec.tsx
@@ -6,6 +6,7 @@ test('safeRelatedReservations handles undefined conversation data', () => {
   expect(safeRelatedReservations(undefined)).toEqual([]);
   expect(safeRelatedReservations(null)).toEqual([]);
   expect(safeRelatedReservations({ related_reservations: undefined } as any)).toEqual([]);
+  expect(safeRelatedReservations('not-an-object' as any)).toEqual([]);
 });
 
 // And when data exists, the helper surfaces it untouched.


### PR DESCRIPTION
## Summary
- harden the guest experience helper to ignore non-object conversation placeholders before accessing related reservations
- extend the guest experience regression coverage to ensure non-object conversations fall back to an empty list

## Testing
- npm test -- guest-experience-guard.spec.tsx
- npm test -- conversation-normalize.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d0534c8618832ab2470a23faf3bc19