### PR TITLE
Fix: robust conversation deep link resolution and redirector pass-through

### DIFF
--- a/app/go/c/[token]/route.ts
+++ b/app/go/c/[token]/route.ts
@@ -68,7 +68,9 @@ export async function resolveConversationToken(token: string | null | undefined)
   try {
     const uuid = await resolveConversationUuid(raw, {
       allowMintFallback: false,
-      skipRedirectProbe: true,
+      // Enable redirect probe so legacy ids / slugs succeed even when the
+      // internal resolver or alias cache is unavailable.
+      skipRedirectProbe: false,
     });
     if (uuid && UUID_RE.test(uuid)) {
       return uuid.toLowerCase();

--- a/apps/redirector/app.js
+++ b/apps/redirector/app.js
@@ -683,6 +683,21 @@ export function createRedirectorApp() {
     return headOk({ 'Content-Type': 'application/json' });
   });
 
+  // Pass-through for universal deep links accidentally pointed at the redirector host.
+  // Always forward to the app host's /go/c/:token so these links never 404.
+  app.get('/go/c/:token', (c) => {
+    const base = cleanBaseUrl();
+    const token = c.req.param('token') || '';
+    const location = `${base}/go/c/${encodeURIComponent(token)}`;
+    return redirectResponse(c, location);
+  });
+  app.on('HEAD', '/go/c/:token', (c) => {
+    const base = cleanBaseUrl();
+    const token = c.req.param('token') || '';
+    const location = `${base}/go/c/${encodeURIComponent(token)}`;
+    return headSeeOther(location);
+  });
+
   app.get('/link/help', () => ok(fallbackHtml()));
   app.on('HEAD', '/link/help', () => headOk({ 'Content-Type': 'text/html; charset=utf-8' }));
 


### PR DESCRIPTION
## Summary
- enable redirect probing when resolving /go/c tokens to fall back on redirector lookups
- add redirector pass-through for /go/c/:token requests so misconfigured hosts forward correctly
- extend deep link e2e coverage with a redirector forwarding regression test

## Testing
- `npx playwright test e2e/deeplink-redirect.spec.ts` *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d07da71b7c832abc576ec19a0c20fa