### PR TITLE
feat: include guest full name in SLA alert email

### DIFF
--- a/cron.mjs
+++ b/cron.mjs
@@ -518,6 +518,160 @@ function buildGuestLabel(source) {
   return guestName ? `Guest ${guestName}` : 'Guest';
 }
 
+function deriveGuestFullName(context) {
+  if (!context) return 'Guest';
+  if (Array.isArray(context)) {
+    const fromArray = extractGuestName(context);
+    return fromArray && fromArray.trim().length ? fromArray.trim() : 'Guest';
+  }
+
+  const names = [];
+  const push = (...values) => {
+    for (const value of values) {
+      if (value == null) continue;
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed) names.push(trimmed);
+        continue;
+      }
+      if (Array.isArray(value)) {
+        const fromParticipants = findNameInParticipants(value);
+        if (fromParticipants) {
+          names.push(fromParticipants);
+        }
+        continue;
+      }
+      if (typeof value === 'object') {
+        const direct = tryNameFromValue(value);
+        if (direct) {
+          names.push(direct);
+        }
+      }
+    }
+  };
+
+  const fromParts = (first, last) => {
+    const partA = first == null ? '' : String(first).trim();
+    const partB = last == null ? '' : String(last).trim();
+    const joined = [partA, partB].filter(Boolean).join(' ');
+    return joined || null;
+  };
+
+  const addGuestShapes = (guest) => {
+    if (!guest) return;
+    push(guest);
+    push(guest.profile, guest.person, guest.user, guest.contact, guest.details, guest.info);
+    push(guest.fullName, guest.full_name, guest.name, guest.display_name, guest.displayName);
+    push(guest.guestFullName, guest.guest_full_name);
+    push(
+      fromParts(
+        guest.preferred_first_name ?? guest.preferredFirstName ?? guest.first_name ?? guest.firstName ?? guest.given_name ?? guest.givenName,
+        guest.preferred_last_name ?? guest.preferredLastName ?? guest.last_name ?? guest.lastName ?? guest.family_name ?? guest.familyName,
+      ),
+    );
+  };
+
+  push(
+    context.guestFullName,
+    context.guest_full_name,
+    context.guestName,
+    context.guest_name,
+    fromParts(context.guestFirstName ?? context.guest_first_name, context.guestLastName ?? context.guest_last_name),
+  );
+  addGuestShapes(context.guest);
+
+  const conv = context.conversation || {};
+  push(
+    conv.guestFullName,
+    conv.guest_full_name,
+    conv.guestName,
+    conv.guest_name,
+    fromParts(conv.guestFirstName ?? conv.guest_first_name, conv.guestLastName ?? conv.guest_last_name),
+  );
+  addGuestShapes(conv.guest);
+  addGuestShapes(conv.primaryGuest);
+  addGuestShapes(conv.primary_guest);
+  addGuestShapes(context.primaryGuest);
+  addGuestShapes(context.primary_guest);
+  addGuestShapes(context.data?.guest);
+  addGuestShapes(context.data?.primary_guest);
+  addGuestShapes(context.payload?.guest);
+  addGuestShapes(context.payload?.primary_guest);
+  addGuestShapes(context.payload?.data?.guest);
+  addGuestShapes(context.payload?.data?.primary_guest);
+  addGuestShapes(context.raw?.guest);
+  addGuestShapes(context.raw?.primary_guest);
+
+  const participantGroups = [
+    context.participants,
+    context.members,
+    context.people,
+    context.users,
+    context.data?.participants,
+    context.data?.members,
+    context.data?.people,
+    context.data?.users,
+    context.payload?.participants,
+    context.payload?.members,
+    context.payload?.people,
+    context.payload?.users,
+    context.payload?.data?.participants,
+    context.payload?.data?.members,
+    context.payload?.data?.people,
+    context.payload?.data?.users,
+    context.raw?.participants,
+    context.raw?.members,
+    context.raw?.people,
+    context.raw?.users,
+    conv.participants,
+    conv.members,
+    conv.people,
+    conv.users,
+    conv.contacts,
+    conv.attendees,
+    conv.guests,
+  ];
+  for (const group of participantGroups) {
+    const name = findNameInParticipants(group);
+    if (name) names.push(name);
+  }
+
+  const messageSources = [
+    context.messages,
+    context.thread,
+    context.rawMessages,
+    context.raw?.messages,
+    context.raw?.thread,
+    context.data?.messages,
+    context.data?.thread,
+    context.payload?.messages,
+    context.payload?.thread,
+    context.payload?.data?.messages,
+    context.payload?.data?.thread,
+    conv.messages,
+    conv.thread,
+    conv.data?.messages,
+    conv.data?.thread,
+    context.raw?.messages,
+    context.raw?.thread,
+  ];
+  for (const source of messageSources) {
+    const name = extractGuestName(source);
+    if (name) names.push(name);
+  }
+
+  const normalized = [];
+  for (const candidate of names) {
+    if (!candidate) continue;
+    const trimmed = candidate.trim().replace(/\s+/g, ' ');
+    if (!trimmed) continue;
+    if (!normalized.includes(trimmed)) normalized.push(trimmed);
+  }
+
+  const named = normalized.find((value) => value && value.toLowerCase() !== 'guest');
+  return named || 'Guest';
+}
+
 function escapeHtml(s) {
   return String(s ?? '').replace(/[&<>"']/g, c => (
     {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]
@@ -528,6 +682,7 @@ export const __cronTest__ = {
   pickNameLike,
   extractGuestName,
   buildGuestLabel,
+  deriveGuestFullName,
   escapeHtml,
 };
 if (typeof globalThis.__CRON_TEST__ === 'undefined') {
@@ -869,13 +1024,25 @@ for (const { id } of toCheck) {
         try {
           metrics?.increment?.(metricName);
           const guestLabel = buildGuestLabel(messagesRaw || msgs);
-          const guestName = extractGuestName(messagesRaw || msgs);
-          const safeGuestName = guestName ? escapeHtml(guestName) : null;
+          const guestFullName = deriveGuestFullName({
+            conversation: conv,
+            guest: conv?.guest ?? conv?.primary_guest ?? conv?.primaryGuest,
+            messages: msgs,
+            rawMessages: messagesRaw,
+            thread: conv?.thread,
+          });
+          const safeGuestFullName = escapeHtml(guestFullName);
+          const summaryNameCandidate =
+            guestFullName && guestFullName !== 'Guest'
+              ? guestFullName
+              : extractGuestName(messagesRaw || msgs);
+          const summaryName = summaryNameCandidate && summaryNameCandidate.trim().length ? summaryNameCandidate.trim() : null;
+          const safeGuestName = summaryName ? escapeHtml(summaryName) : null;
           const guestSummaryHtml = safeGuestName
             ? `Guest <strong>${safeGuestName}</strong> has been waiting for <strong>${ageMin} minutes</strong>.`
             : `A guest has been waiting for <strong>${ageMin} minutes</strong>.`;
-          const guestSummaryText = guestName
-            ? `Guest ${guestName} has been waiting for ${ageMin} minutes (SLA ${SLA_MIN}m).`
+          const guestSummaryText = summaryName
+            ? `Guest ${summaryName} has been waiting for ${ageMin} minutes (SLA ${SLA_MIN}m).`
             : `A guest has been waiting for ${ageMin} minutes (SLA ${SLA_MIN}m).`;
           await sendAlertEmail({
             to,
@@ -886,6 +1053,7 @@ for (const { id } of toCheck) {
       <div style="max-width:560px;margin:0 auto;background-color:#ffffff;border:1px solid #e2e8f0;border-radius:12px;padding:24px;">
         <p style="margin:0 0 24px;font-size:14px;font-weight:600;color:#0ea5e9;">Boom SLA Alert</p>
         <h1 style="margin:0 0 16px;font-size:22px;font-weight:600;color:#0f172a;">Guest needs attention</h1>
+        <p style="margin:4px 0 12px;font-size:16px;font-weight:600;color:#0f172a;">👤 ${safeGuestFullName}</p>
         <p style="margin:0 0 8px;font-size:16px;line-height:1.5;">${guestSummaryHtml}</p>
         <p style="margin:0 0 16px;font-size:14px;color:#475569;">The SLA for a response is ${SLA_MIN} minutes.</p>
         <div style="padding:16px;border-radius:8px;border:1px solid #e2e8f0;background-color:#f8fafc;">
@@ -898,6 +1066,7 @@ for (const { id } of toCheck) {
     </body>
   </html>`,
             text: `Boom SLA Alert
+Guest: ${guestFullName}
 ${guestSummaryText}
 Conversation ID: ${idDisplay}
 Respond in Boom to assist the guest.${saleFallbackNoteText}`,

--- a/tests/cron-guest-name.spec.ts
+++ b/tests/cron-guest-name.spec.ts
@@ -72,4 +72,20 @@ test.describe('cron guest label helpers', () => {
     const helpers = await loadHelpers();
     expect(helpers.escapeHtml('Guest <>&"\'')).toBe('Guest &lt;&gt;&amp;&quot;&#39;');
   });
+
+  test('deriveGuestFullName prefers conversation guest full name', async () => {
+    const helpers = await loadHelpers();
+    const payload = {
+      conversation: {
+        guest: { full_name: 'Jordan Example' },
+      },
+    };
+    expect(helpers.deriveGuestFullName(payload)).toBe('Jordan Example');
+  });
+
+  test('deriveGuestFullName falls back to Guest when no name available', async () => {
+    const helpers = await loadHelpers();
+    const payload = { conversation: { participants: [{ role: 'agent', profile: { full_name: 'Agent' } }] } };
+    expect(helpers.deriveGuestFullName(payload)).toBe('Guest');
+  });
 });


### PR DESCRIPTION
## Summary
- add deriveGuestFullName helper with resilient fallbacks for guest context data
- surface the guest name line in both cron and manual check SLA email templates
- extend cron helper tests to cover name presence and missing fallbacks

## Testing
- npm test *(fails: Playwright browsers unavailable; additional specs blocked on same launch requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68d170f23ba4832a8ca6a9e3e2b3e074