### PR TITLE
Fix SLA evaluator misclassifying user sender type

### DIFF
--- a/tests/sla-closing.spec.ts
+++ b/tests/sla-closing.spec.ts
@@ -58,6 +58,18 @@ test('treats "Thanks" without goodbye as non-closing', async () => {
   expect(res.ok).toBe(false);
 });
 
+test('agent replies with senderType user end the SLA window', async () => {
+  const { evaluateUnanswered } = await loadEvaluator();
+  const now = new Date();
+  const msgs = [
+    buildGuestMessage('Hello?', 10),
+    { role: 'agent', senderType: 'user', direction: 'outbound', timestamp: Date.now() - 9 * 60000 },
+  ];
+  const res = await evaluateUnanswered(msgs, now, 5);
+  expect(res.ok).toBe(true);
+  expect(res.reason).toBe('no_breach');
+});
+
 test('AI fallback honors confidence', async () => {
   const { isClosingStatement } = await import('../src/lib/isClosingStatement.js');
   process.env.USE_AI_INTENT = '1';

--- a/tests/sla-evaluator.spec.ts
+++ b/tests/sla-evaluator.spec.ts
@@ -105,3 +105,24 @@ test('approved AI responses clear the SLA', async () => {
   expect(result.ok).toBe(true);
   expect(result.reason).toBe('no_breach');
 });
+
+test('agent responses with senderType "user" clear the SLA', async () => {
+  const now = iso('2024-01-01T00:10:00Z');
+  const messages = [
+    { sent_at: '2024-01-01T00:00:00Z', senderType: 'guest', direction: 'inbound', body: 'Need help' },
+    { sent_at: '2024-01-01T00:02:00Z', senderType: 'user', direction: 'outbound', body: 'Sure, happy to help!' },
+  ];
+  const result = await evaluate(messages, now, 5);
+  expect(result.ok).toBe(true);
+  expect(result.reason).toBe('no_breach');
+});
+
+test('inbound messages tagged as "user" still count as guest messages', async () => {
+  const now = iso('2024-01-01T00:10:00Z');
+  const messages = [
+    { sent_at: '2024-01-01T00:00:00Z', senderType: 'user', direction: 'inbound', body: 'Checking in again' },
+  ];
+  const result = await evaluate(messages, now, 5);
+  expect(result.ok).toBe(false);
+  expect(result.reason).toBe('guest_unanswered');
+});


### PR DESCRIPTION
## Summary
- adjust the SLA evaluators to recognise outbound messages with senderType "user" as agent replies
- keep inbound "user"-tagged messages as guest activity by consulting the direction hint
- add regression coverage for both evaluate() helpers to capture the new behaviour

## Testing
- npm test *(fails: Playwright browsers not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68d19a3a3b08832ab7aa9029a037eb2c