### PR TITLE
Refresh SLA alert email presentation

### DIFF
--- a/check.mjs
+++ b/check.mjs
@@ -1171,8 +1171,10 @@ if (typeof globalThis.__CHECK_TEST__ === "undefined") {
       <html lang="en">
         <body style="margin:0;padding:24px;background-color:#f8fafc;font-family:'Inter','Segoe UI',Arial,sans-serif;color:#0f172a;">
           <div style="max-width:560px;margin:0 auto;background-color:#ffffff;border:1px solid #e2e8f0;border-radius:12px;padding:24px;">
-            <p style="margin:0 0 24px;font-size:14px;font-weight:600;color:#0ea5e9;">Boom SLA Alert</p>
-            <h1 style="margin:0 0 16px;font-size:22px;font-weight:600;color:#0f172a;">Guest needs attention</h1>
+            <div style="margin:0 0 24px;padding:18px;border-radius:16px;background:linear-gradient(135deg,#0ea5e9,#6366f1);">
+              <p style="margin:0;font-size:12px;font-weight:600;letter-spacing:0.08em;text-transform:uppercase;color:#e0f2fe;">Boom SLA Alert</p>
+              <h1 style="margin:12px 0 0;font-size:24px;font-weight:700;color:#ffffff;">Guest needs attention</h1>
+            </div>
             <p style="margin:4px 0 12px;font-size:16px;font-weight:600;color:#0f172a;">👤 ${safeGuestFullName}</p>
             <p style="margin:0 0 8px;font-size:16px;line-height:1.5;">${guestSummaryHtml}</p>
             <p style="margin:0 0 16px;font-size:14px;color:#475569;">The SLA for a response is ${SLA_MINUTES} minutes.</p>

--- a/email.mjs
+++ b/email.mjs
@@ -11,6 +11,7 @@ import nodemailer from "nodemailer";
  *   - ALERT_TO
  * Optional:
  *   - ALERT_FROM_NAME
+ *   - ALERT_FROM_ADDRESS
  *
  * @param {object} opts
  * @param {string} opts.subject Email subject
@@ -23,7 +24,8 @@ export async function sendAlert({ subject, html, text }) {
   const user = process.env.SMTP_USER;
   const pass = process.env.SMTP_PASS;
   const to   = process.env.ALERT_TO;
-  const fromName = process.env.ALERT_FROM_NAME || "Boom SLA Bot";
+  const fromName = process.env.ALERT_FROM_NAME || "Boom SLA Alert";
+  const fromAddress = process.env.ALERT_FROM_ADDRESS || user;
 
   if (!host || !port || !user || !pass || !to) {
     console.log("Alert needed, but SMTP/recipient envs are not fully set.");
@@ -38,7 +40,7 @@ export async function sendAlert({ subject, html, text }) {
   });
 
   const message = {
-    from: `"${fromName}" <${user}>`,
+    from: fromName ? { name: fromName, address: fromAddress } : fromAddress,
     to,
     subject,
     text,


### PR DESCRIPTION
## Summary
- restyle the SLA alert email header with a gradient banner and emphasize the call to action in the subject line while removing the conversation id
- allow configuring a formal display name/address for the alert sender so the email no longer shows the raw SMTP account

## Testing
- npm test *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d19eb022f8832aa5d3b682728bf869