### PR TITLE
Adjust user role classification and alert tolerance

### DIFF
--- a/check.mjs
+++ b/check.mjs
@@ -517,8 +517,8 @@ function classifyMessage(m) {
   }
 
   if (userToken) {
-    if (directionRole === "guest") return { role: "guest", aiStatus };
-    return { role: "agent", aiStatus };
+    if (directionRole === "agent") return { role: "agent", aiStatus };
+    return { role: "guest", aiStatus };
   }
 
   // Messages from the host/agent. In some datasets the role may be

--- a/cron.mjs
+++ b/cron.mjs
@@ -268,8 +268,8 @@ function classifyMessage(m) {
   if (isAI) return { role: "ai", aiStatus: aiStat };
   if (/(guest|customer)/.test(byRaw)) return { role: "guest", aiStatus: aiStat };
   if ((byCanonical === "user" || byCanonical === "users" || /\buser\b/.test(byRaw))) {
-    if (directionRole === "guest") return { role: "guest", aiStatus: aiStat };
-    return { role: "agent", aiStatus: aiStat };
+    if (directionRole === "agent") return { role: "agent", aiStatus: aiStat };
+    return { role: "guest", aiStatus: aiStat };
   }
   if (byRaw) return { role: "agent", aiStatus: aiStat };
   if (directionRole) return { role: directionRole, aiStatus: aiStat };
@@ -703,8 +703,8 @@ export function shouldAlertAge(ageMinutes, { slaMinutes, toleranceMinutes = 0 } 
   if (!Number.isFinite(age)) return true;
   const sla = Number(slaMinutes) || 0;
   const tolerance = Math.max(0, Number(toleranceMinutes) || 0);
-  if (age + tolerance < sla) return false;
-  return age >= sla;
+  // Trigger when age is at least SLA minus tolerance (i.e., allow small clock drift).
+  return age >= Math.max(0, sla - tolerance);
 }
 
 export const __cronTest__ = {


### PR DESCRIPTION
## Summary
- treat generic `user` senders as guests unless the message direction is outbound
- update cron classification to mirror the new guest-first heuristic
- allow SLA alerts to fire once age reaches SLA minus tolerance to absorb small clock drift

## Testing
- npx playwright test tests/sla-evaluator.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d2d093fe24832aa200eec78c1630fe