### PR TITLE
Fix SLA evaluator to avoid hiding guest status updates

### DIFF
--- a/check.mjs
+++ b/check.mjs
@@ -486,9 +486,24 @@ function classifyMessage(m) {
     "assignment",
     "fun",
   ];
-  const combo = `${moduleVal} ${msgType} ${body}`;
-  const matches = sysKeywords.filter((k) => combo.includes(k));
-  if (matches.length >= 2 && !["guest", "customer", "user", "users"].includes(byCanonical)) {
+  const keywordMatches = new Set();
+  const structuredMatches = new Set();
+  for (const keyword of sysKeywords) {
+    if (moduleVal.includes(keyword) || msgType.includes(keyword)) {
+      keywordMatches.add(keyword);
+      structuredMatches.add(keyword);
+      continue;
+    }
+    if (body.includes(keyword)) {
+      keywordMatches.add(keyword);
+    }
+  }
+  if (
+    keywordMatches.size >= 2 &&
+    structuredMatches.size >= 1 &&
+    directionRole !== "guest" &&
+    !["guest", "customer", "user", "users"].includes(byCanonical)
+  ) {
     return { role: "internal", aiStatus };
   }
   // Treat single-token automation/system/bot/auto-reply as internal unless inbound from a guest.

--- a/tests/sla-evaluator.spec.ts
+++ b/tests/sla-evaluator.spec.ts
@@ -59,6 +59,16 @@ test('Thanks alone in another language does not bypass SLA ("gracias")', async (
   expect(result.reason).toBe('guest_unanswered');
 });
 
+test('guest questions mentioning status updates still trigger the SLA', async () => {
+  const now = iso('2024-01-01T00:10:00Z');
+  const messages = [
+    { sent_at: '2024-01-01T00:00:00Z', direction: 'inbound', body: 'Any status update on the repair?' },
+  ];
+  const result = await evaluate(messages, now, 5);
+  expect(result.ok).toBe(false);
+  expect(result.reason).toBe('guest_unanswered');
+});
+
 test('internal notes do not satisfy the SLA window', async () => {
   const now = iso('2024-01-01T00:10:00Z');
   const messages = [


### PR DESCRIPTION
## Summary
- refine the internal-note keyword heuristic so only messages with system metadata are filtered, preventing inbound guest "status update" questions from being ignored
- add a regression test proving that guest status update follow-ups keep the SLA breach detection active

## Testing
- npm test *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ec36b0f4832a97fbc39956629149