### PR TITLE
fix: prevent unresolved statuses from triggering resolution guard

### DIFF
--- a/src/lib/isResolved.js
+++ b/src/lib/isResolved.js
@@ -13,6 +13,19 @@ const RESOLVED_TOKENS = [
   'ended',
 ];
 
+const NEGATED_PATTERNS = [
+  /\bunresolved\b/i,
+  /\bnot\s+resolved\b/i,
+  /\bnot\s+closed\b/i,
+  /\bre[-\s]?opened\b/i,
+  /\bopen\b/i,
+  /\bin[-\s]?progress\b/i,
+  /\bpending\b/i,
+  /\bawaiting\b/i,
+  /\bwaiting\b/i,
+  /\bongoing\b/i,
+];
+
 function isTrue(v) {
   if (v === true) return true;
   const s = String(v ?? '').trim().toLowerCase();
@@ -34,6 +47,20 @@ function tok(v) {
   return String(v ?? '').toLowerCase();
 }
 
+function normalizeStatus(status) {
+  return tok(status).replace(/[_-]+/g, ' ');
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function containsWord(haystack, needle) {
+  if (!haystack || !needle) return false;
+  const pattern = new RegExp(`(^|\\b)${escapeRegExp(needle)}(\\b|$)`, 'i');
+  return pattern.test(haystack);
+}
+
 function any(obj, keys) {
   for (const k of keys) {
     if (obj && typeof obj === 'object' && k in obj) return obj[k];
@@ -52,8 +79,9 @@ function flagsResolved(obj) {
     'archived', 'is_archived', 'isArchived',
   ];
   for (const k of flagKeys) if (isTrue(obj[k])) return true;
-  const s = tok(status);
-  if (s && RESOLVED_TOKENS.some((t) => s.includes(t))) return true;
+  const s = normalizeStatus(status);
+  if (s && NEGATED_PATTERNS.some((re) => re.test(s))) return false;
+  if (s && RESOLVED_TOKENS.some((t) => containsWord(s, t))) return true;
   const tsKeys = ['resolved_at', 'resolvedAt', 'closed_at', 'closedAt', 'archived_at', 'archivedAt', 'done_at', 'doneAt'];
   for (const k of tsKeys) if (parseTs(obj[k])) return true;
   return false;
@@ -79,8 +107,10 @@ function messageMarksResolved(m) {
   const body = tok(m.body ?? m.body_text ?? m.text ?? m.message ?? m.content);
   const combo = `${moduleVal} ${typeVal} ${body}`;
   // Look for system/workflow/status changes that clearly resolve/close
-  if (/(system|workflow|status|policy|automation)/.test(moduleVal + typeVal) &&
-      /(resolve|closed|archiv|done|complete|solved)/.test(combo)) {
+  const isSystemy = /(system|workflow|status|policy|automation)/.test(moduleVal + typeVal);
+  const neg = /\b(unresolved|not\s+resolved|not\s+closed|re-?opened?)\b/i;
+  const pos = /\b(resolved?|closed|archiv(?:e|ed|ing)?|done|complete(?:d)?|solved|finished|ended)\b/i;
+  if (isSystemy && !neg.test(combo) && pos.test(combo)) {
     return true;
   }
   return false;

--- a/tests/sla-resolved.spec.ts
+++ b/tests/sla-resolved.spec.ts
@@ -20,3 +20,25 @@ test('stays false for open threads', async () => {
   const ctx = { conversation: { status: 'open' } };
   expect(isConversationResolved(ctx, [])).toBe(false);
 });
+
+test('does not treat negated statuses as resolved', async () => {
+  const statuses = ['Unresolved', 'not_resolved', 'not resolved', 'in_progress', 'reopened'];
+  for (const status of statuses) {
+    const ctx = { conversation: { status } };
+    expect(isConversationResolved(ctx, [])).toBe(false);
+  }
+});
+
+test('ignores unresolved system messages', async () => {
+  const messages = [
+    { module: 'status', type: 'change', body: 'Status changed to unresolved' },
+  ];
+  expect(isConversationResolved({}, messages)).toBe(false);
+});
+
+test('ignores conversation reopened messages', async () => {
+  const messages = [
+    { module: 'system', type: 'update', body: 'Conversation reopened by agent' },
+  ];
+  expect(isConversationResolved({}, messages)).toBe(false);
+});


### PR DESCRIPTION
## Summary
- add negation patterns, normalized status matching, and safe word checks to resolution guard
- tighten system message detection to require positive resolution phrases without negations
- extend SLA resolution tests to cover unresolved statuses and reopened messages

## Testing
- npm ci
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d31bbe70ac832aae0fb30e493458a0