### PR TITLE
SLA alerts: add inbound DB guard to `check.mjs` to prevent alerts on empty conversations

### DIFF
--- a/tests/inbound-guard.spec.ts
+++ b/tests/inbound-guard.spec.ts
@@ -16,6 +16,11 @@ test('pickConversationIdForGuard returns lowercase uuid', () => {
   expect(picked).toBe('01890b14-b4cd-7eef-b13e-bb8c083bad60');
 });
 
+test('pickConversationIdForGuard flattens nested arrays of candidates', () => {
+  const picked = pickConversationIdForGuard(['', [' ', [''], ['987']], '01890B14-B4CD-7EEF-B13E-BB8C083BAD60']);
+  expect(picked).toBe('987');
+});
+
 test('ensureVisibleInboundMessage skips when id missing', async () => {
   const calls: any[] = [];
   const result = await ensureVisibleInboundMessage('', {


### PR DESCRIPTION
## Summary
- add the inbound DB guard earlier in the `check.mjs` alert flow so empty conversations are skipped
- expand the inbound guard spec to cover nested candidate arrays

## Testing
- `npm test --silent` *(fails: `tests/internal-resolver.spec.ts` expects one internal resolver call when run with the full suite; passes when run alone)*
- `npx playwright test --workers=1` *(fails for the same reason as above)*
- `npx playwright test tests/internal-resolver.spec.ts -g "falls back"`


------
https://chatgpt.com/codex/tasks/task_e_68d3f024d32c832ab3ef91f4144c3f5d