### PR TITLE
SLA guard: prefer numeric conversation_id; fix suppression of real breaches

### DIFF
--- a/check.mjs
+++ b/check.mjs
@@ -1156,15 +1156,16 @@ if (typeof globalThis.__CHECK_TEST__ === "undefined") {
     }
     // --- DB guard: only alert when there is a visible inbound guest message
     try {
+      // Prefer numeric conversation identifiers; UUIDs last as fallback.
       const guardCandidates = [
-        linkObj?.uuid,
+        data?.conversation?.id,
         linkObj?.legacyId,
+        data?.conversation?.legacyId,
         linkObj?.primary,
         linkObj?.additional || [],
-        data?.conversation?.id,
-        data?.conversation?.uuid,
-        data?.conversation?.legacyId,
         convId,
+        linkObj?.uuid,
+        data?.conversation?.uuid,
       ];
       const guardConversationId = pickConversationIdForGuard(guardCandidates);
       if (guardConversationId) {

--- a/lib/inboundGuard.js
+++ b/lib/inboundGuard.js
@@ -35,13 +35,14 @@ function normalizeId(value) {
 }
 
 export function pickConversationIdForGuard(candidates = []) {
-  for (const raw of flattenCandidates(candidates)) {
-    const normalized = normalizeId(raw);
-    if (!normalized) continue;
-    if (NUMERIC_RE.test(normalized)) return normalized;
-    if (UUID_RE.test(normalized.toLowerCase())) return normalized.toLowerCase();
-  }
-  return null;
+  // Flatten + normalize once
+  const flat = flattenCandidates(candidates).map(normalizeId).filter(Boolean);
+  // Prefer numeric conversation_id anywhere in the list
+  const numeric = flat.find(v => NUMERIC_RE.test(v));
+  if (numeric) return numeric;
+  // Fallback to a canonical lowercase UUID if present
+  const uuid = flat.find(v => UUID_RE.test(String(v).toLowerCase()));
+  return uuid ? String(uuid).toLowerCase() : null;
 }
 
 export async function ensureVisibleInboundMessage(conversationId, { logger, context, query } = {}) {

--- a/tests/inbound-guard.spec.ts
+++ b/tests/inbound-guard.spec.ts
@@ -16,6 +16,11 @@ test('pickConversationIdForGuard returns lowercase uuid', () => {
   expect(picked).toBe('01890b14-b4cd-7eef-b13e-bb8c083bad60');
 });
 
+test('pickConversationIdForGuard prefers numeric anywhere in the list (uuid first)', () => {
+  const picked = pickConversationIdForGuard(['01890b14-b4cd-7eef-b13e-bb8c083bad60', '42']);
+  expect(picked).toBe('42');
+});
+
 test('pickConversationIdForGuard flattens nested arrays of candidates', () => {
   const picked = pickConversationIdForGuard(['', [' ', [''], ['987']], '01890B14-B4CD-7EEF-B13E-BB8C083BAD60']);
   expect(picked).toBe('987');


### PR DESCRIPTION
**Problem**
The pre-send inbound-message guard queries Postgres by numeric `conversation_id`, but the one-off `check.mjs` path often passed a UUID first. The helper `pickConversationIdForGuard` returned the first matching token (UUID), causing the DB lookup to fail and legitimate alerts to be suppressed.

**Fix**
- Make `pickConversationIdForGuard` prefer numeric ids across the candidate list; fallback to UUID.
- Reorder `check.mjs` guard candidates to numeric-first (defense-in-depth).
- Add a unit test to prevent regressions.

This preserves the empty-conversation protection without dropping real unresolved breaches.

------
https://chatgpt.com/codex/tasks/task_e_68d455300908832a8ec654c65d6dba25